### PR TITLE
Replace OrderedDict used in model with defaultdict

### DIFF
--- a/markovify/chain.py
+++ b/markovify/chain.py
@@ -3,7 +3,7 @@ import itertools
 import operator
 import bisect
 import json
-from collections import OrderedDict
+from collections import defaultdict
 
 BEGIN = "___BEGIN__"
 END = "___END__"
@@ -49,18 +49,13 @@ class Chain(object):
         """
         if (type(corpus) != list) or (type(corpus[0]) != list):
             raise Exception("`corpus` must be list of lists")
-        model = OrderedDict()
+        model = defaultdict(lambda: defaultdict(int))
         for run in corpus:
             items = ([ BEGIN ] * state_size) + run + [ END ]
             for i in range(len(run) + 1):
                 state = tuple(items[i:i+state_size])
                 follow = items[i+state_size]
-                if state not in model:
-                    model[state] = OrderedDict(((follow, 1), ))
-                elif follow not in model[state]:
-                    model[state][follow] = 1
-                else:
-                    model[state][follow] += 1
+                model[state][follow] += 1
         return model
 
     def move(self, state):
@@ -117,7 +112,7 @@ class Chain(object):
         else:
             obj = json_thing
         state_size = len(obj[0][0])
-        rehydrated = OrderedDict((tuple(item[0]), item[1]) for item in obj)
+        rehydrated = {tuple(item[0]): item[1] for item in obj}
         inst = cls(None, state_size, rehydrated)
         return inst
 


### PR DESCRIPTION
Having the entries in the model kept in the same order that they were
added doesn't seem to be necessary for any reason, and OrderedDict is
fairly slow. With a large corpus, using a defaultdict here instead is
significantly faster.

---

I found this improvement while doing some profiling on SubredditSimulator today to find bottlenecks that were causing it to take a very long time to generate comments sometimes. Using a corpus of 50,000 reddit comments, creating so many `OrderedDict`s for the model was taking a significant amount of the runtime (trimmed to only relevant lines):

    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
         1    0.000    0.000   69.525   69.525 chain.py:29(__init__)
         1   10.181   10.181   69.525   69.525 chain.py:43(build)
    940462   16.249    0.000   54.432    0.000 collections.py:38(__init__)

And with the same corpus after changing to a `defaultdict` instead:

    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
         1    0.000    0.000    8.430    8.430 chain.py:29(__init__)
         1    5.457    5.457    8.430    8.430 chain.py:43(build)   

So that's about an 8x speedup on `Chain.__init__` with this data.