### PR TITLE
Improve memory usage

### DIFF
--- a/markovify/chain.py
+++ b/markovify/chain.py
@@ -1,9 +1,7 @@
 import random
-import itertools
 import operator
 import bisect
 import json
-from collections import defaultdict
 
 BEGIN = "___BEGIN__"
 END = "___END__"
@@ -49,12 +47,22 @@ class Chain(object):
         """
         if (type(corpus) != list) or (type(corpus[0]) != list):
             raise Exception("`corpus` must be list of lists")
-        model = defaultdict(lambda: defaultdict(int))
+
+        # Using a DefaultDict here would be a lot more convenient, however the memory
+        # usage is far higher.
+        model = {}
+
         for run in corpus:
             items = ([ BEGIN ] * state_size) + run + [ END ]
             for i in range(len(run) + 1):
                 state = tuple(items[i:i+state_size])
                 follow = items[i+state_size]
+                if state not in model:
+                    model[state] = {}
+
+                if follow not in model[state]:
+                    model[state][follow] = 0
+
                 model[state][follow] += 1
         return model
 


### PR DESCRIPTION
I've replaced the DefaultDict with an ordinary dict. This drastically improves memory usage. Below are two memory profile readings using the `pympler` library, both using a similar sized input text, the first using the current code and the second using a normal dict.

											  types |   # objects |   total size
	=============================================== | =========== | ============
					<class 'collections.defaultdict |     2067202 |    739.46 MB
										<class 'str |       32110 |    283.73 MB
									   <class 'dict |        6464 |      3.94 MB
									   <class 'code |       12342 |      1.70 MB
									   <class 'type |        1468 |      1.45 MB
									  <class 'tuple |        5335 |    359.73 KB
										<class 'set |         897 |    329.97 KB
									<class 'weakref |        2994 |    233.91 KB
	  <class 'sqlalchemy.sql.visitors.VisitableType |         213 |    217.30 KB
									   <class 'list |        1991 |    194.40 KB
										<class 'int |        3818 |    115.28 KB
								function (__init__) |         833 |    110.63 KB
						  <class 'getset_descriptor |        1525 |    107.23 KB
						 <class 'wrapper_descriptor |        1299 |    101.48 KB
		  <class 'traitlets.traitlets.MetaHasTraits |          77 |     94.96 KB

											  types |   # objects |   total size
	=============================================== | =========== | ============
										<class 'str |       32128 |    282.66 MB
									   <class 'dict |        6466 |     99.94 MB
									   <class 'code |       12341 |      1.70 MB
									   <class 'type |        1468 |      1.45 MB
									  <class 'tuple |        5340 |    360.04 KB
										<class 'set |         899 |    331.41 KB
									<class 'weakref |        2994 |    233.91 KB
	  <class 'sqlalchemy.sql.visitors.VisitableType |         213 |    217.30 KB
									   <class 'list |        1993 |    194.62 KB
								function (__init__) |         833 |    110.63 KB
						  <class 'getset_descriptor |        1525 |    107.23 KB
										<class 'int |        3383 |    103.38 KB
						 <class 'wrapper_descriptor |        1299 |    101.48 KB
		  <class 'traitlets.traitlets.MetaHasTraits |          77 |     94.96 KB
						  <class 'collections.deque |         150 |     92.58 KB

As you can see, the memory usage in the second run is considerably lower. The code is not as nice, but the gains are massive (600+mb in this case, with 10x as many input characters I've seen memory usage from from over 14gb to 4).

Edit: Hmm, is there perhaps a memory leak somewhere? `2067202` DeafultDict objects is a lot, especially when there are only `6466` dict objects in the second snapshot. I've been re-testing it the results are consistent.