### PR TITLE
add Text.from_chain class method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.eggs
 
 # Installer logs
 pip-log.txt

--- a/markovify/chain.py
+++ b/markovify/chain.py
@@ -23,7 +23,7 @@ class Chain(object):
     A Markov chain representing processes that have both beginnings and ends.
     For example: Sentences.
     """
-    def __init__(self, corpus, state_size, model=None):
+    def __init__(self, corpus, state_size=None, model=None):
         """
         `corpus`: A list of lists, where each outer list is a "run"
         of the process (e.g., a single sentence), and each inner list
@@ -34,8 +34,8 @@ class Chain(object):
         `state_size`: An integer indicating the number of items the model
         uses to represent its state. For text generation, 2 or 3 are typical.
         """
-        self.state_size = state_size
-        self.model = model or self.build(corpus, state_size)
+        self.state_size = state_size or 2
+        self.model = model or self.build(corpus, self.state_size)
 
     def build(self, corpus, state_size):
         """

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+from . import test_basic

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -46,5 +46,11 @@ class MarkovifyTest(unittest.TestCase):
         sent = text_model.make_sentence_with_start("Sherlock Holmes")
         assert(sent != None)
 
+    def test_short_sentence(self):
+        text_model = markovify.Text(self.sherlock)
+        sent = text_model.make_short_sentence(45)
+        assert len(sent) < 45
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -1,35 +1,50 @@
-import random
+import unittest
 import markovify
 import sys, os
 import operator
 
-HERE = os.path.dirname(os.path.realpath(__file__))
-with open(os.path.join(HERE, "texts/sherlock.txt")) as f:
-    sherlock = f.read()
-
-def test_text_too_small():
-    text = u"Example phrase. This is another example sentence."
-    text_model = markovify.Text(text)
-    assert(text_model.make_sentence() == None)
-
-def test_sherlock():
-    text_model = markovify.Text(sherlock)
-    sent = text_model.make_sentence()
-    assert(len(sent) != 0)
-
 def get_sorted(chain_json):
     return sorted(chain_json, key=operator.itemgetter(0))
 
-def test_json():
-    text_model = markovify.Text(sherlock)
-    chain_json = text_model.chain.to_json()
-    stored_chain = markovify.Chain.from_json(chain_json)
-    assert(get_sorted(stored_chain.to_json()) == get_sorted(chain_json))
-    new_text_model = markovify.Text(sherlock, chain=stored_chain)
-    sent = text_model.make_sentence()
-    assert(len(sent) != 0)
+class MarkovifyTest(unittest.TestCase):
 
-def test_make_sentence_with_start():
-    text_model = markovify.Text(sherlock)
-    sent = text_model.make_sentence_with_start("Sherlock Holmes")
-    assert(sent != None)
+    def setUp(self):
+        with open(os.path.join(os.path.dirname(__file__), "texts/sherlock.txt")) as f:
+            self.sherlock = f.read()
+
+    def test_text_too_small(self):
+        text = u"Example phrase. This is another example sentence."
+        text_model = markovify.Text(text)
+        assert(text_model.make_sentence() == None)
+
+    def test_sherlock(self):
+        text_model = markovify.Text(self.sherlock)
+        sent = text_model.make_sentence()
+        assert(len(sent) != 0)
+
+    def test_json(self):
+        text_model = markovify.Text(self.sherlock)
+
+        sent = text_model.make_sentence()
+        assert(len(sent) != 0)
+
+    def test_chain(self):
+        text_model = markovify.Text(self.sherlock)
+        chain_json = text_model.chain.to_json()
+
+        stored_chain = markovify.Chain.from_json(chain_json)
+        assert(get_sorted(stored_chain.to_json()) == get_sorted(chain_json))
+
+        new_text_model = markovify.Text.from_chain(chain_json)
+        assert(get_sorted(new_text_model.chain.to_json()) == get_sorted(chain_json))
+
+        sent = new_text_model.make_sentence()
+        assert(len(sent) != 0)
+
+    def test_make_sentence_with_start(self):
+        text_model = markovify.Text(self.sherlock)
+        sent = text_model.make_sentence_with_start("Sherlock Holmes")
+        assert(sent != None)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py31,py34
+envlist = py26,py27,py31,py34,py35
 
 [testenv]
 deps=nose


### PR DESCRIPTION
The docs mention recreating a `Text` class from an existing model, but it's a little involved. This pull adds a `Text.from_chain` method, analagous to `Chain.from_json`.

I also cleaned up some non-pythonic default setting, and wrapped tests in unittest, added a couple of test functions, and added python 3.5 to `tox.ini`.

One small change: I changed to relative imports from absolute, which could foul up testing.
