### PR TITLE
Fix for Text.from_chain

### DIFF
--- a/markovify/text.py
+++ b/markovify/text.py
@@ -186,7 +186,7 @@ class Text(object):
         If corpus is None, overlap checking won't work.
         """
         chain = Chain.from_json(chain_json)
-        return cls(corpus or '', None, chain=chain)
+        return cls(corpus or '', state_size=chain.state_size, chain=chain)
 
 
 class NewlineText(Text):


### PR DESCRIPTION
Fixed Text.from_chain so that it returns the actual state_size of the loaded chain.

Text.from_chain was returning a Text instance with state_size of None, which causes markovify to crash when running functions that rely on self.state_size, such as make_sentence_with_start()