### PR TITLE
Save 'runs' to exported models

### DIFF
--- a/markovify/text.py
+++ b/markovify/text.py
@@ -36,7 +36,7 @@ class Text(object):
         return {
             "input_text": self.input_text,
             "state_size": self.state_size,
-            "chain": self.chain.to_json()
+            "chain": self.chain.to_json(),
             "runs": self.runs
         }
 
@@ -48,7 +48,7 @@ class Text(object):
         return cls(
             obj["input_text"],
             state_size=obj["state_size"],
-            chain=Chain.from_json(obj["chain"])
+            chain=Chain.from_json(obj["chain"]),
             runs=obj["runs"]
         )
 

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -185,13 +185,13 @@ class Text(object):
         return self.make_sentence(init_state, **kwargs)
 
     @classmethod
-    def from_chain(cls, chain_json, corpus=None):
+    def from_chain(cls, chain_json, corpus=None, parsed_sentences=None):
         """
         Init a Text class based on an existing chain JSON string or object
         If corpus is None, overlap checking won't work.
         """
         chain = Chain.from_json(chain_json)
-        return cls(corpus or '', state_size=chain.state_size, chain=chain)
+        return cls(corpus or '', parsed_sentences=parsed_sentences, state_size=chain.state_size, chain=chain)
 
 
 class NewlineText(Text):

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -44,6 +44,7 @@ class Text(object):
     @classmethod
     def from_dict(cls, obj):
         return cls(
+            None,
             state_size=obj["state_size"],
             chain=Chain.from_json(obj["chain"]),
             parsed_sentences=obj["parsed_sentences"]

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -24,9 +24,8 @@ class Text(object):
               an infinite process, you can come very close by passing just one, very
               long run.
         """
-        self.input_text = input_text
         self.state_size = state_size
-        self.parsed_sentences = parsed_sentences or list(self.generate_corpus(self.input_text))
+        self.parsed_sentences = parsed_sentences or list(self.generate_corpus(input_text))
 
         # Rejoined text lets us assess the novelty of generated sentences
         self.rejoined_text = self.sentence_join(map(self.word_join, self.parsed_sentences))
@@ -34,7 +33,6 @@ class Text(object):
 
     def to_dict(self):
         return {
-            "input_text": self.input_text,
             "state_size": self.state_size,
             "chain": self.chain.to_json(),
             "parsed_sentences": self.parsed_sentences
@@ -46,7 +44,6 @@ class Text(object):
     @classmethod
     def from_dict(cls, obj):
         return cls(
-            obj["input_text"],
             state_size=obj["state_size"],
             chain=Chain.from_json(obj["chain"]),
             parsed_sentences=obj["parsed_sentences"]

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -13,25 +13,31 @@ class ParamError(Exception):
 
 class Text(object):
 
-    def __init__(self, input_text, state_size=2, chain=None):
+    def __init__(self, input_text, state_size=2, chain=None, runs=None):
         """
         input_text: A string.
         state_size: An integer, indicating the number of words in the model's state.
         chain: A trained markovify.Chain instance for this text, if pre-processed.
+        runs: A list of lists, where each outer list is a "run"
+              of the process (e.g., a single sentence), and each inner list
+              contains the steps (e.g., words) in the run. If you want to simulate
+              an infinite process, you can come very close by passing just one, very
+              long run.
         """
         self.input_text = input_text
         self.state_size = state_size
-        runs = list(self.generate_corpus(input_text))
+        self.runs = runs or list(self.generate_corpus(self.input_text))
 
         # Rejoined text lets us assess the novelty of generated setences
-        self.rejoined_text = self.sentence_join(map(self.word_join, runs))
-        self.chain = chain or Chain(runs, state_size)
+        self.rejoined_text = self.sentence_join(map(self.word_join, self.runs))
+        self.chain = chain or Chain(self.runs, state_size)
 
     def to_dict(self):
         return {
             "input_text": self.input_text,
             "state_size": self.state_size,
             "chain": self.chain.to_json()
+            "runs": self.runs
         }
 
     def to_json(self):
@@ -43,6 +49,7 @@ class Text(object):
             obj["input_text"],
             state_size=obj["state_size"],
             chain=Chain.from_json(obj["chain"])
+            runs=obj["runs"]
         )
 
     @classmethod

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -13,31 +13,31 @@ class ParamError(Exception):
 
 class Text(object):
 
-    def __init__(self, input_text, state_size=2, chain=None, runs=None):
+    def __init__(self, input_text, state_size=2, chain=None, parsed_sentences=None):
         """
         input_text: A string.
         state_size: An integer, indicating the number of words in the model's state.
         chain: A trained markovify.Chain instance for this text, if pre-processed.
-        runs: A list of lists, where each outer list is a "run"
-              of the process (e.g., a single sentence), and each inner list
-              contains the steps (e.g., words) in the run. If you want to simulate
+        parsed_sentences: A list of lists, where each outer list is a "run"
+              of the process (e.g. a single sentence), and each inner list
+              contains the steps (e.g. words) in the run. If you want to simulate
               an infinite process, you can come very close by passing just one, very
               long run.
         """
         self.input_text = input_text
         self.state_size = state_size
-        self.runs = runs or list(self.generate_corpus(self.input_text))
+        self.parsed_sentences = parsed_sentences or list(self.generate_corpus(self.input_text))
 
-        # Rejoined text lets us assess the novelty of generated setences
-        self.rejoined_text = self.sentence_join(map(self.word_join, self.runs))
-        self.chain = chain or Chain(self.runs, state_size)
+        # Rejoined text lets us assess the novelty of generated sentences
+        self.rejoined_text = self.sentence_join(map(self.word_join, self.parsed_sentences))
+        self.chain = chain or Chain(self.parsed_sentences, state_size)
 
     def to_dict(self):
         return {
             "input_text": self.input_text,
             "state_size": self.state_size,
             "chain": self.chain.to_json(),
-            "runs": self.runs
+            "parsed_sentences": self.parsed_sentences
         }
 
     def to_json(self):
@@ -49,7 +49,7 @@ class Text(object):
             obj["input_text"],
             state_size=obj["state_size"],
             chain=Chain.from_json(obj["chain"]),
-            runs=obj["runs"]
+            parsed_sentences=obj["parsed_sentences"]
         )
 
     @classmethod

--- a/markovify/utils.py
+++ b/markovify/utils.py
@@ -46,7 +46,7 @@ def combine(models, weights=None):
         combined_sentences = []
         for m in models:
             combined_sentences += m.parsed_sentences
-        return ret_inst.from_chain(c)
+        return ret_inst.from_chain(c, parsed_sentences=combined_sentences)
     if isinstance(ret_inst, list):
         return list(c.items())
     if isinstance(ret_inst, dict):

--- a/markovify/utils.py
+++ b/markovify/utils.py
@@ -43,8 +43,10 @@ def combine(models, weights=None):
     if isinstance(ret_inst, Chain):
         return Chain.from_json(c)
     if isinstance(ret_inst, Text):
-        combined_text = "\n".join(m.input_text for m in models)
-        return ret_inst.from_chain(c, corpus=combined_text)
+        combined_sentences = []
+        for m in models:
+            combined_sentences += m.parsed_sentences
+        return Text(input_text=None, parsed_sentences=combined_sentences)
     if isinstance(ret_inst, list):
         return list(c.items())
     if isinstance(ret_inst, dict):

--- a/markovify/utils.py
+++ b/markovify/utils.py
@@ -46,7 +46,7 @@ def combine(models, weights=None):
         combined_sentences = []
         for m in models:
             combined_sentences += m.parsed_sentences
-        return Text(input_text=None, parsed_sentences=combined_sentences)
+        return ret_inst.from_chain(c)
     if isinstance(ret_inst, list):
         return list(c.items())
     if isinstance(ret_inst, dict):


### PR DESCRIPTION
Added `runs` to the exported model to save run-time when a Text model is instantiated from an existing JSON/dict. With the current markovify there isn't really much time saved by loading an exported model, but by saving `runs` the time is more than halved.

Please let me know what you think.

Benchmarking method (see [gist](https://gist.github.com/ammgws/9d2b4d278ae281d3ef282c437c0cef5e))
a) Create new model from scratch `markovify.Text(corpus, state_size=2, chain=None)`
b) Load an existing chain JSON `markovify.Text.from_chain(chain_json, corpus=corpus)`
c) Load an existing model JSON `markovify.Text.from_json(model_json)`

**Current markovify**
- a) RasPi 16.2 secs, Desktop 0.24 secs
- b) RasPi 14.1 secs, Desktop 0.22 secs
- c) RasPi 15.4 secs, Desktop 0.25 secs

**This branch**
- a) RasPi 16.3 secs, Desktop 0.23 secs
- b) RasPi 13.7 secs, Desktop 0.21 secs
- c) RasPi 06.3 secs, Desktop 0.10 secs

RasPi = Raspberry Pi 2
Desktop = Intel i5-3570K CPU @ 3.40GHz, 8GB RAM