### PR TITLE
Two new args for make_sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Notes:
 
 - By default, the `make_sentence` method tries, a maximum of 10 times per invocation, to make a sentence that doesn't overlap too much with the original text. If it is successful, the method returns the sentence as a string. If not, it returns `None`. To increase or decrease the number of attempts, use the `tries` keyword argument, e.g., call `.make_sentence(tries=100)`.
 
-- By default, `markovify.Text` tries to generate sentences that don't simply regurgitate chunks of the original text. The default rule is to suppress any generated sentences that exactly overlaps the original text by 15 words or 70% of the sentence's word count. You can change this rule by passing `max_overlap_ratio` and/or `max_overlap_total` to the `make_sentence` method.
+- By default, `markovify.Text` tries to generate sentences that don't simply regurgitate chunks of the original text. The default rule is to suppress any generated sentences that exactly overlaps the original text by 15 words or 70% of the sentence's word count. You can change this rule by passing `max_overlap_ratio` and/or `max_overlap_total` to the `make_sentence` method. Alternatively you can disable this check entirely by passing `test_output` as False.
 
 ## Advanced Usage
 

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -132,10 +132,18 @@ class Text(object):
         If `init_state` (a tuple of `self.chain.state_size` words) is not specified,
         this method chooses a sentence-start at random, in accordance with
         the model.
+        
+        If `test_output` is passed as False then the `test_sentence_output` check
+        will be skipped.
+        
+        If `max_words` is passed the word count for the sentence will be
+        evaluated against the provided limit.
         """
         tries = kwargs.get('tries', DEFAULT_TRIES)
         mor = kwargs.get('max_overlap_ratio', DEFAULT_MAX_OVERLAP_RATIO)
         mot = kwargs.get('max_overlap_total', DEFAULT_MAX_OVERLAP_TOTAL)
+        test_output = kwargs.get('test_output', True)
+        max_words = kwargs.get('max_words', None)
 
         for _ in range(tries):
             if init_state != None:
@@ -146,7 +154,12 @@ class Text(object):
             else:
                 prefix = []
             words = prefix + self.chain.walk(init_state)
-            if self.test_sentence_output(words, mor, mot):
+            if max_words != None and len(words) > max_words:
+                continue
+            if test_output:
+                if self.test_sentence_output(words, mor, mot):
+                    return self.word_join(words)
+            else:
                 return self.word_join(words)
         return None
 

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -133,10 +133,10 @@ class Text(object):
         this method chooses a sentence-start at random, in accordance with
         the model.
         
-        If `test_output` is passed as False then the `test_sentence_output` check
+        If `test_output` is set as False then the `test_sentence_output` check
         will be skipped.
         
-        If `max_words` is passed the word count for the sentence will be
+        If `max_words` is specified, the word count for the sentence will be
         evaluated against the provided limit.
         """
         tries = kwargs.get('tries', DEFAULT_TRIES)


### PR DESCRIPTION
Been working on a chat bot of my own that utilizes markovify and have modified a few things in the process. Two are relatively simple and could be useful for others:

- `max_words` to limit sentence length by word count.
 - `test_output` to allow disabling the `test_sentence_output` checking entirely. Not commonly needed but it has helped at times during testing and exploring how things work.

Both should also work through any method that passes **kwargs to `make_sentence`.