### PR TITLE
Add optional `char_min` argument to make_short_sentence.

### DIFF
--- a/markovify/text.py
+++ b/markovify/text.py
@@ -152,19 +152,20 @@ class Text(object):
 
     def make_short_sentence(self, char_limit, **kwargs):
         """
-        Tries making a sentence of no more than `char_limit` characters`,
-        passing **kwargs to `self.make_sentence`.
+        Tries making a sentence of no more than `char_limit` characters` and optionally
+        no less than `char_min` charcaters, passing **kwargs to `self.make_sentence`.
         """
         tries = kwargs.get('tries', DEFAULT_TRIES)
+        char_min = kwargs.get('char_min', 0)
         for _ in range(tries):
             sentence = self.make_sentence(**kwargs)
-            if sentence and len(sentence) < char_limit:
+            if sentence and len(sentence) < char_limit and len(sentence) > char_min:
                 return sentence
 
     def make_sentence_with_start(self, beginning, **kwargs):
         """
         Tries making a sentence that begins with `beginning` string,
-        which should be a string of one or two words known to exist in the 
+        which should be a string of one or two words known to exist in the
         corpus. **kwargs are passed to `self.make_sentence`.
         """
         split = self.word_split(beginning)

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -74,7 +74,11 @@ class MarkovifyTest(unittest.TestCase):
         while sent == None:
             sent = text_model.make_short_sentence(45)
         assert len(sent) < 45
-
+        sent = None
+        while sent == None:
+            sent = text_model.make_short_sentence(100,char_min=50)
+        assert len(sent) < 100
+        assert len(sent) > 50
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add optional `char_min` argument to make_short_sentence. Add argument to test case.

Adds ability to pass a minimum length of sentence to return. Ex. make_short_sentence(140, char_min=70) will return a sentence of length 70 < len < 140