### PR TITLE
Combine models with retain_original=False, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ You can also export the underlying Markov chain on its own — i.e., excluding 
 
 ### Generating `markovify.Text` models from very large corpora
 
-By default, the `markovify.Text` class loads, and retains, the your textual corpus, so that it can compare generated sentences with the original (and only emit novel sentences). But, with very large corpora, loading the entire text at once (and retaining it) can be memory-intensive. To overcome this, you can `(a)` read in the corpus line-by-line, and `(b)` tell Markovify not to retain the original:
+By default, the `markovify.Text` class loads, and retains, the your textual corpus, so that it can compare generated sentences with the original (and only emit novel sentences). But, with very large corpora, loading the entire text at once (and retaining it) can be memory-intensive. To overcome this, you can `(a)` tell Markovify not to retain the original:
 
 ```python
 with open("path/to/my/huge/corpus.txt") as f:
@@ -156,6 +156,18 @@ with open("path/to/my/huge/corpus.txt") as f:
 print(text_model.make_sentence())
 ```
 
+And `(b)` read in the corpus line-by-line or file-by-file and combine it into one model at the end:
+
+```python
+models = []
+for (dirpath, _, filenames) in os.walk("path/to/my/huge/corpus"):
+    for filename in filenames:
+        with open(os.path.join(dirpath, filename)) as f:
+            models.append(markovify.Text(f, retain_original=False))
+
+combined_model = markovify.combine(models)
+print(combined_model.make_sentence())
+```
 
 ## Markovify In The Wild
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ class POSifiedText(markovify.Text):
         return sentence
 ```
 
+Or, you can use [spaCy](https://spacy.io/) which is [way faster](https://spacy.io/docs/api/#benchmarks):
+
+```python
+import markovify
+import re
+import spacy
+
+nlp = spacy.load("en")
+
+class POSifiedText(markovify.Text):
+    def word_split(self, sentence):
+        return ["::".join((word.orth_, word.pos_)) for word in nlp(sentence)]
+
+    def word_join(self, words):
+        sentence = " ".join(word.split("::")[0] for word in words)
+        return sentence
+```
+
 The most useful `markovify.Text` models you can override are:
 
 - `sentence_split`

--- a/markovify/utils.py
+++ b/markovify/utils.py
@@ -45,10 +45,13 @@ def combine(models, weights=None):
     if isinstance(ret_inst, Chain):
         return Chain.from_json(c)
     if isinstance(ret_inst, Text):
-        combined_sentences = []
-        for m in models:
-            combined_sentences += m.parsed_sentences
-        return ret_inst.from_chain(c, parsed_sentences=combined_sentences)
+        if ret_inst.retain_original:
+            combined_sentences = []
+            for m in models:
+                combined_sentences += m.parsed_sentences
+            return ret_inst.from_chain(c, parsed_sentences=combined_sentences)
+        else:
+            return ret_inst.from_chain(c)
     if isinstance(ret_inst, list):
         return list(c.items())
     if isinstance(ret_inst, dict):

--- a/test/test_itertext.py
+++ b/test/test_itertext.py
@@ -28,6 +28,17 @@ class MarkovifyTest(unittest.TestCase):
         assert sent is not None
         assert len(sent) != 0
 
+    def test_from_mult_files_without_retaining(self):
+        models = []
+        for (dirpath, _, filenames) in os.walk(os.path.join(os.path.dirname(__file__), "texts")):
+            for filename in filenames:
+                with open(os.path.join(dirpath, filename)) as f:
+                    models.append(markovify.Text(f, retain_original=False))
+        combined_model = markovify.combine(models)
+        sent = combined_model.make_sentence()
+        assert sent is not None
+        assert len(sent) != 0
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
Thanks for making this library, it's really great and easy to use. I was trying to load a large corpus file-by-file and noticed an error when trying to use `markovify.combine` on models with `retain_original=False`:

```
AttributeError: 'Text' object has no attribute 'parsed_sentences'
```
I think this change fixes the issue.

And, I documented how to create models file-by-file and combine them into one model in the README. I was wondering how to do that when I first started using markovify.

Also, kind of unrelated, but I added a tip about using spaCy to the README too.