### PR TITLE
Fix combining models with mixed retain_original values

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,20 +174,7 @@ with open("path/to/my/huge/corpus.txt") as f:
 print(text_model.make_sentence())
 ```
 
-And `(b)` read in the corpus line-by-line or file-by-file and combine it into one model at the end:
-
-```python
-models = []
-for (dirpath, _, filenames) in os.walk("path/to/my/huge/corpus"):
-    for filename in filenames:
-        with open(os.path.join(dirpath, filename)) as f:
-            models.append(markovify.Text(f, retain_original=False))
-
-combined_model = markovify.combine(models)
-print(combined_model.make_sentence())
-```
-
-To save more memory, you might want to combine the models as they are generated so you only have at most two models in memory:
+And `(b)` read in the corpus line-by-line or file-by-file and combine them into one model at each step:
 
 ```python
 combined_model = None
@@ -202,6 +189,7 @@ for (dirpath, _, filenames) in os.walk("path/to/my/huge/corpus"):
 
 print(combined_model.make_sentence())
 ```
+
 
 ## Markovify In The Wild
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,22 @@ combined_model = markovify.combine(models)
 print(combined_model.make_sentence())
 ```
 
+To save more memory, you might want to combine the models as they are generated so you only have at most two models in memory:
+
+```python
+combined_model = None
+for (dirpath, _, filenames) in os.walk("path/to/my/huge/corpus"):
+    for filename in filenames:
+        with open(os.path.join(dirpath, filename)) as f:
+            model = markovify.Text(file, retain_original=False)
+            if combined_model:
+                combined_model = markovify.combine(models=[combined_model, model])
+            else:
+                combined_model = model
+
+print(combined_model.make_sentence())
+```
+
 ## Markovify In The Wild
 
 - BuzzFeed's [Tom Friedman Sentence Generator](http://www.buzzfeed.com/jsvine/the-tom-friedman-sentence-generator) / [@mot_namdeirf](https://twitter.com/mot_namdeirf).

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -225,7 +225,7 @@ class Text(object):
         If corpus is None, overlap checking won't work.
         """
         chain = Chain.from_json(chain_json)
-        return cls(corpus or '', parsed_sentences=parsed_sentences, state_size=chain.state_size, chain=chain)
+        return cls(corpus or None, parsed_sentences=parsed_sentences, state_size=chain.state_size, chain=chain)
 
 
 class NewlineText(Text):

--- a/markovify/utils.py
+++ b/markovify/utils.py
@@ -45,10 +45,11 @@ def combine(models, weights=None):
     if isinstance(ret_inst, Chain):
         return Chain.from_json(c)
     if isinstance(ret_inst, Text):
-        if ret_inst.retain_original:
+        if any(m.retain_original for m in models):
             combined_sentences = []
             for m in models:
-                combined_sentences += m.parsed_sentences
+                if m.retain_original:
+                    combined_sentences += m.parsed_sentences
             return ret_inst.from_chain(c, parsed_sentences=combined_sentences)
         else:
             return ret_inst.from_chain(c)

--- a/test/test_combine.py
+++ b/test/test_combine.py
@@ -9,6 +9,7 @@ def get_sorted(chain_json):
 with open(os.path.join(os.path.dirname(__file__), "texts/sherlock.txt")) as f:
     sherlock = f.read()
     sherlock_model = markovify.Text(sherlock)
+    sherlock_model_no_retain = markovify.Text(sherlock, retain_original=False)
 
 class MarkovifyTest(unittest.TestCase):
 
@@ -54,6 +55,17 @@ class MarkovifyTest(unittest.TestCase):
             text_model_a = sherlock_model
             text_model_b = markovify.NewlineText(sherlock)
             combo = markovify.combine([ text_model_a, text_model_b ])
+
+    def test_combine_no_retain(self):
+        text_model = sherlock_model_no_retain
+        combo = markovify.combine([ text_model, text_model ])
+        assert(combo.retain_original == False)
+
+    def test_combine_retain_and_no_retain(self):
+        text_model_a = sherlock_model_no_retain
+        text_model_b = sherlock_model
+        combo = markovify.combine([ text_model_a, text_model_b ])
+        assert(not combo.retain_original)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_combine.py
+++ b/test/test_combine.py
@@ -59,13 +59,21 @@ class MarkovifyTest(unittest.TestCase):
     def test_combine_no_retain(self):
         text_model = sherlock_model_no_retain
         combo = markovify.combine([ text_model, text_model ])
-        assert(combo.retain_original == False)
+        assert(not combo.retain_original)
 
-    def test_combine_retain_and_no_retain(self):
+    def test_combine_retain_on_no_retain(self):
         text_model_a = sherlock_model_no_retain
         text_model_b = sherlock_model
         combo = markovify.combine([ text_model_a, text_model_b ])
-        assert(not combo.retain_original)
+        assert(combo.retain_original)
+        assert(combo.parsed_sentences == text_model_b.parsed_sentences)
+
+    def test_combine_no_retain_on_retain(self):
+        text_model_a = sherlock_model_no_retain
+        text_model_b = sherlock_model
+        combo = markovify.combine([ text_model_b, text_model_a ])
+        assert(combo.retain_original)
+        assert(combo.parsed_sentences == text_model_b.parsed_sentences)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR tries to fix two issues:

**1**

When combining models that had `retain_original=False` set, the resulting combined model had `retain_original=True` despite having no parsed_sentences.

The fix is to make `Text.from_chain` (which combine uses) pass `input_text=None` instead of `input_text=''` to the Text constructor when no source corpus is specified. This makes can_make_sentences False, in turn making the model's retain_original attribute also False.

**2**

If you were combining models and the first model had `retain_original=True` but another in the list had `retain_original=False` then it would break on trying to access parsed_sentences on the model that didn't have any.

Now, if any model in the list of Text models to combine has `retain_original=True` then the resulting combined model will have `retain_original=True` and it will only combine the retained parsed_sentences that it can find in the models array.
