### PR TITLE
Add update method to Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,20 +174,16 @@ with open("path/to/my/huge/corpus.txt") as f:
 print(text_model.make_sentence())
 ```
 
-And `(b)` read in the corpus line-by-line or file-by-file and combine them into one model at each step:
+And `(b)` read in the corpus line-by-line or file-by-file and iteratively build the model with `model.update()`:
 
 ```python
-combined_model = None
+model = markovify.Text('', retain_original=False)
 for (dirpath, _, filenames) in os.walk("path/to/my/huge/corpus"):
     for filename in filenames:
         with open(os.path.join(dirpath, filename)) as f:
-            model = markovify.Text(f, retain_original=False)
-            if combined_model:
-                combined_model = markovify.combine(models=[combined_model, model])
-            else:
-                combined_model = model
+                model.update(f)
 
-print(combined_model.make_sentence())
+print(model.make_sentence())
 ```
 
 


### PR DESCRIPTION
Sorry to overwhelm you with yet another PR. I'm playing around with trying to make markovify models out of huge corpus and I keep finding ways to eke out a little more saved memory.

This is mainly useful for incrementally building one Text from separate chunks of a corpus too large to store in memory all at once. This is slightly better than using `combine()` which requires you to have the overhead of at least two models in memory at once.

Chain now accepts `base_model` which the new Text update method uses.

I also tweaked how Text/Chain behave when you initialize them with `None` or `''` so that you can initialize an empty Text without it throwing an exception and then later call `update()` on it.