### PR TITLE
Changed model input file name in readme line-by-line example

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ combined_model = None
 for (dirpath, _, filenames) in os.walk("path/to/my/huge/corpus"):
     for filename in filenames:
         with open(os.path.join(dirpath, filename)) as f:
-            model = markovify.Text(file, retain_original=False)
+            model = markovify.Text(f, retain_original=False)
             if combined_model:
                 combined_model = markovify.combine(models=[combined_model, model])
             else:


### PR DESCRIPTION
Variable name mismatch in the line-by-line example of the readme.

In the example, the file is opened as 'f' but the input passed in as an argument to markovify.Text() is 'file'