### PR TITLE
Add Jython .class files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ html/sentences
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*$py.class
 
 # C extensions
 *.so


### PR DESCRIPTION
When running Markovify in Jython, .class files are generated for compiled bytecode instead of .pyc files.