### PR TITLE
Allow reject pattern disabling / modification

### DIFF
--- a/markovify/text.py
+++ b/markovify/text.py
@@ -14,6 +14,8 @@ class ParamError(Exception):
 
 class Text(object):
 
+    reject_pat = re.compile(r"(^')|('$)|\s'|'\s|[\"(\(\)\[\])]")
+
     def __init__(self, input_text, state_size=2, chain=None, parsed_sentences=None, retain_original=True):
         """
         input_text: A string.
@@ -101,14 +103,13 @@ class Text(object):
         in a randomly-generated sentence.
         """
         if len(sentence.strip()) == 0: return False
-        reject_pat = re.compile(r"(^')|('$)|\s'|'\s|[\"(\(\)\[\])]")
         # Decode unicode, mainly to normalize fancy quotation marks
         if sentence.__class__.__name__ == "str": # pragma: no cover
             decoded = sentence
         else: # pragma: no cover
             decoded = unidecode(sentence)
         # Sentence shouldn't contain problematic characters
-        if re.search(reject_pat, decoded): return False
+        if self.reject_pat.search(decoded): return False
         return True
 
     def generate_corpus(self, text):

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -16,7 +16,7 @@ class Text(object):
 
     reject_pat = re.compile(r"(^')|('$)|\s'|'\s|[\"(\(\)\[\])]")
 
-    def __init__(self, input_text, state_size=2, chain=None, parsed_sentences=None, retain_original=True):
+    def __init__(self, input_text, state_size=2, chain=None, parsed_sentences=None, retain_original=True, well_formed=True, reject_pat=''):
         """
         input_text: A string.
         state_size: An integer, indicating the number of words in the model's state.
@@ -41,6 +41,10 @@ class Text(object):
             if not chain:
                 parsed = parsed_sentences or self.generate_corpus(input_text)
             self.chain = chain or Chain(parsed, state_size)
+
+        self.well_formed = well_formed
+        if well_formed and reject_pat != '':
+            self.reject_pat = re.compile(reject_pat)
 
     def to_dict(self):
         """
@@ -109,7 +113,7 @@ class Text(object):
         else: # pragma: no cover
             decoded = unidecode(sentence)
         # Sentence shouldn't contain problematic characters
-        if self.reject_pat.search(decoded): return False
+        if self.well_formed and self.reject_pat.search(decoded): return False
         return True
 
     def generate_corpus(self, text):

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -16,7 +16,7 @@ class Text(object):
 
     reject_pat = re.compile(r"(^')|('$)|\s'|'\s|[\"(\(\)\[\])]")
 
-    def __init__(self, input_text, state_size=2, chain=None, parsed_sentences=None, retain_original=True, well_formed=True, reject_pat=''):
+    def __init__(self, input_text, state_size=2, chain=None, parsed_sentences=None, retain_original=True, well_formed=True, reject_reg=''):
         """
         input_text: A string.
         state_size: An integer, indicating the number of words in the model's state.
@@ -26,6 +26,12 @@ class Text(object):
               contains the steps (e.g. words) in the run. If you want to simulate
               an infinite process, you can come very close by passing just one, very
               long run.
+        retain_original: Indicates whether to keep the original corpus.
+        well_formed: Indicates whether sentences should be well-formed, preventing
+              unmatched quotes, parenthesis by default, or a custom regular expression
+              can be provided.
+        reject_reg: If well_formed is True, this can be provided to override the
+              standard rejection pattern.
         """
         can_make_sentences = parsed_sentences is not None or input_text is not None
         self.retain_original = retain_original and can_make_sentences
@@ -43,8 +49,8 @@ class Text(object):
             self.chain = chain or Chain(parsed, state_size)
 
         self.well_formed = well_formed
-        if well_formed and reject_pat != '':
-            self.reject_pat = re.compile(reject_pat)
+        if well_formed and reject_reg != '':
+            self.reject_pat = re.compile(reject_reg)
 
     def to_dict(self):
         """

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -33,6 +33,11 @@ class Text(object):
         reject_reg: If well_formed is True, this can be provided to override the
               standard rejection pattern.
         """
+
+        self.well_formed = well_formed
+        if well_formed and reject_reg != '':
+            self.reject_pat = re.compile(reject_reg)
+            
         can_make_sentences = parsed_sentences is not None or input_text is not None
         self.retain_original = retain_original and can_make_sentences
         self.state_size = state_size
@@ -47,10 +52,6 @@ class Text(object):
             if not chain:
                 parsed = parsed_sentences or self.generate_corpus(input_text)
             self.chain = chain or Chain(parsed, state_size)
-
-        self.well_formed = well_formed
-        if well_formed and reject_reg != '':
-            self.reject_pat = re.compile(reject_reg)
 
     def to_dict(self):
         """

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -37,7 +37,7 @@ class Text(object):
         self.well_formed = well_formed
         if well_formed and reject_reg != '':
             self.reject_pat = re.compile(reject_reg)
-            
+
         can_make_sentences = parsed_sentences is not None or input_text is not None
         self.retain_original = retain_original and can_make_sentences
         self.state_size = state_size
@@ -109,7 +109,7 @@ class Text(object):
 
     def test_sentence_input(self, sentence):
         """
-        A basic sentence filter. This one rejects sentences that contain
+        A basic sentence filter. The default rejects sentences that contain
         the type of punctuation that would look strange on its own
         in a randomly-generated sentence.
         """

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -147,5 +147,9 @@ class MarkovifyTest(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             markovify.Chain.from_json(1)
 
+    def test_custom_regex(self):
+        with self.assertRaises(Exception) as context:
+            model = markovify.NewlineText('This sucks.', reject_reg=r'sucks')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds two parameters to `Text` initialization, `well_formed` and `reject_reg`.

- `well_formed` allows you to prevent checking to see if one of the 'bad characters' i.e. `()[]'"` is in the corpus. As this behaviour probably isn't desired in most cases, the default is to keep sentences well-formed.
- `reject_reg` allows different pattern checking for bad data as opposed to the default for flexibility purposes. This only applies if `well_formed` is True, and if the expression is non-empty.