### PR TITLE
add Stackexchange Simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ print(combined_model.make_sentence())
 - [@CanDennisDream](https://twitter.com/CanDennisDream), a twitter bot that contemplates life by training on existential literature discussions. [[code](https://github.com/GiantsLoveDeathMetal/dennis_bot)]
 - [B-9 Indifference](https://github.com/eoinnoble/b9-indifference), a program that generates a _Star Trek: The Next Generation_ script of arbitrary length using Markov chains trained on the show’s episode and movie scripts. [[code](https://github.com/eoinnoble/b9-indifference)]
 - [adam](http://bziarkowski.pl/adam), polish poetry generator. [[code](https://github.com/bziarkowski/adam)]
-- [Stackexchange Simulator](https://se-simulator.lw1.at/), using Stackexchange Dumps to generate random Questions and Answers [[code](https://github.com/Findus23/se-simulator)]
+- [Stackexchange Simulator](https://se-simulator.lw1.at/), using Stackexchange dumps to generate random questions and answers [[code](https://github.com/Findus23/se-simulator)]
 
 Have other examples? Pull requests welcome.
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ print(combined_model.make_sentence())
 - [@CanDennisDream](https://twitter.com/CanDennisDream), a twitter bot that contemplates life by training on existential literature discussions. [[code](https://github.com/GiantsLoveDeathMetal/dennis_bot)]
 - [B-9 Indifference](https://github.com/eoinnoble/b9-indifference), a program that generates a _Star Trek: The Next Generation_ script of arbitrary length using Markov chains trained on the show’s episode and movie scripts. [[code](https://github.com/eoinnoble/b9-indifference)]
 - [adam](http://bziarkowski.pl/adam), polish poetry generator. [[code](https://github.com/bziarkowski/adam)]
+- [Stackexchange Simulator](https://se-simulator.lw1.at/), using Stackexchange Dumps to generate random Questions and Answers [[code](https://github.com/Findus23/se-simulator)]
 
 Have other examples? Pull requests welcome.
 


### PR DESCRIPTION
Hi everyone,

I spent the last month writing a python script that takes all stackoverflow and stackexchanges sites and generates new questions, answers and usernames. 

The questions can be filtered by site and voted on so that the best get on the frontpage.
And there is a quiz where one can guess which of the 150+ Stackexchange sites a question is based on.

https://se-simulator.lw1.at/

I hope you like it.