### PR TITLE
Add min_words optional argument to make_sentence

### DIFF
--- a/markovify/text.py
+++ b/markovify/text.py
@@ -190,14 +190,15 @@ class Text(object):
         If `test_output` is set as False then the `test_sentence_output` check
         will be skipped.
 
-        If `max_words` is specified, the word count for the sentence will be
-        evaluated against the provided limit.
+        If `max_words` or `min_words` are specified, the word count for the sentence will be
+        evaluated against the provided limit(s).
         """
         tries = kwargs.get('tries', DEFAULT_TRIES)
         mor = kwargs.get('max_overlap_ratio', DEFAULT_MAX_OVERLAP_RATIO)
         mot = kwargs.get('max_overlap_total', DEFAULT_MAX_OVERLAP_TOTAL)
         test_output = kwargs.get('test_output', True)
         max_words = kwargs.get('max_words', None)
+        min_words = kwargs.get('min_words', None)
 
         if init_state != None:
             prefix = list(init_state)
@@ -211,7 +212,7 @@ class Text(object):
 
         for _ in range(tries):
             words = prefix + self.chain.walk(init_state)
-            if max_words != None and len(words) > max_words:
+            if max_words != None and len(words) > max_words or len(words) < min_words:
                 continue
             if test_output and hasattr(self, "rejoined_text"):
                 if self.test_sentence_output(words, mor, mot):

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -131,6 +131,11 @@ class MarkovifyTestBase(unittest.TestCase):
         sent = text_model.make_sentence(max_words=0)
         assert sent is None
 
+    def test_min_words(self):
+        text_model = self.sherlock_model
+        sent = text_model.make_sentence(min_words=5)
+        assert len(sent.split(' ')) >= 5
+
     def test_newline_text(self):
         with open(os.path.join(os.path.dirname(__file__), "texts/senate-bills.txt")) as f:
             model = markovify.NewlineText(f.read())


### PR DESCRIPTION
Lets us specify the minimum number of words we want in the sentence. 

Complements the `max_words` optional argument.

Example:

```
model.make_sentence(min_words=10)
```