### PR TITLE
Add python 3.7 test in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
 install:
     - pip install .
     - pip install nose


### PR DESCRIPTION
Python 3.7 is supported but is currently missing from the Travis configuration file.