### PR TITLE
Add python 3.8 test in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - "3.5"
     - "3.6"
     - "3.7"
+    - "3.8"
 install:
     - pip install .
     - pip install nose


### PR DESCRIPTION
The Python 3.8 support is great! However, it is not being tested on Travis CI at the moment: https://travis-ci.org/github/jsvine/markovify/builds/701114376.