### PR TITLE
Fix intermittent test_make_sentence_with_start_three_words failure

### DIFF
--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -106,7 +106,7 @@ class MarkovifyTestBase(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             text_model.make_sentence_with_start(start_str)
         text_model = self.sherlock_model_ss3
-        sent = text_model.make_sentence_with_start("Sherlock")
+        sent = text_model.make_sentence_with_start("Sherlock", tries=50)
         assert(markovify.chain.BEGIN not in sent)
 
     def test_short_sentence(self):


### PR DESCRIPTION
This change will reduce/eliminate occurrences of failures in the `test_make_sentence_with_start_three_words` test case as described in #134. The last 5 failures in [this list](https://travis-ci.org/github/jsvine/markovify/builds) are from this specific test case. The `tries=50` option is also being used in other calls to `make_sentence_with_start`.

When tested locally, before the change, the tests failed on average once every five times. With the fix, I ran the tests 50 times without any failures.