### PR TITLE
Fix intermittent coverage bug

### DIFF
--- a/markovify/text.py
+++ b/markovify/text.py
@@ -213,7 +213,7 @@ class Text(object):
         for _ in range(tries):
             words = prefix + self.chain.walk(init_state)
             if (max_words != None and len(words) > max_words) or (min_words != None and len(words) < min_words):
-                continue
+                continue # pragma: no cover # see https://github.com/nedbat/coveragepy/issues/198
             if test_output and hasattr(self, "rejoined_text"):
                 if self.test_sentence_output(words, mor, mot):
                     return self.word_join(words)


### PR DESCRIPTION
As seen [here](https://coveralls.io/repos/154795/builds), the coverage report oscillates between 100% and 99.67%. The specific line that is sometimes missed can be seen [here](https://coveralls.io/builds/31815527/source?filename=markovify/text.py#L216).

After some digging, I found that this problem is caused by a CPython optimization where the `continue` statement is not explicitly executed when it follows a `if True or *:` statement. The problem is discussed at https://github.com/nedbat/coveragepy/issues/198.

The fix is not ideal but should not cause any future errors. The `test_max_words` and `test_min_words` tests should make sure that this not covered statement is run when needed.