### PR TITLE
Edge case fix in determining sentence enders.

### DIFF
--- a/markovify/splitters.py
+++ b/markovify/splitters.py
@@ -15,7 +15,7 @@ abbr_capped = "|".join([
     "|".join(ascii_lowercase) # Initials
 ]).split("|")
 
-abbr_lowercase = "etc|v|vs|viz|al|pct"
+abbr_lowercase = "etc|v|vs|viz|al|pct".split("|")
 
 exceptions = "U.S.|U.N.|E.U.|F.B.I.|C.I.A.".split("|")
 


### PR DESCRIPTION
If you have sentences (split by dots) ending in non-english words such as "et" or "vi", then function [`is_abbreviation(dotted_word)`](https://github.com/jsvine/markovify/compare/master...rokala:master#diff-330fedaa8bdcc9004f8849fbaf936287R37) will falsely return `True`, and function `is_sentence_ender(word)` will consequently falsely return `False`.

Splitting the string in to a array ensures that `is_abbreviation(dotted_word)` only matches the whole abbreviation.
