### PR TITLE
Add Python 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - "3.6"
     - "3.7"
     - "3.8"
+    - "3.9"
 install:
     - pip install .
     - pip install nose

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Some reasons:
 
 - Relies only on pure-Python libraries, and very few of them.
 
-- Tested on Python 2.7, 3.4, 3.5, 3.6, 3.7, and 3.8.
+- Tested on Python 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, and 3.9.
 
 
 ## Installation

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     keywords="markov chain text",
     author="Jeremy Singer-Vine",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py38
+envlist = py27,py34,py35,py36,py37,py38,py39
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv]


### PR DESCRIPTION
Would you consider dropping support for Python 2.7, 3.4, and 3.5 (all of them after EOL)?