### PR TITLE
Modernize the code to Python 3.6+

### DIFF
--- a/markovify/chain.py
+++ b/markovify/chain.py
@@ -24,7 +24,7 @@ def compile_next(next_dict):
     cff = list(accumulate(next_dict.values()))
     return [words, cff]
 
-class Chain(object):
+class Chain:
     """
     A Markov chain representing processes that have both beginnings and ends.
     For example: Sentences.
@@ -149,7 +149,7 @@ class Chain(object):
             obj = json_thing
 
         if isinstance(obj, list):
-            rehydrated = dict((tuple(item[0]), item[1]) for item in obj)
+            rehydrated = {tuple(item[0]): item[1] for item in obj}
         elif isinstance(obj, dict):
             rehydrated = obj
         else:

--- a/markovify/splitters.py
+++ b/markovify/splitters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*- 
 import re
 
 uppercase_letter_pat = re.compile(r"^[A-Z]$", re.UNICODE)

--- a/markovify/splitters.py
+++ b/markovify/splitters.py
@@ -1,36 +1,46 @@
 import re
 
 uppercase_letter_pat = re.compile(r"^[A-Z]$", re.UNICODE)
-initialism_pat = re.compile(r"^[A-Za-z0-9]{1,2}(\.[A-Za-z0-9]{1,2})+\.$", re.UNICODE)
+initialism_pat = re.compile(r"^[A-Za-z0-9]{1,2}(\.[A-Za-z0-9]{1,2})+\.$",
+                            re.UNICODE)
 
 # States w/ with thanks to https://github.com/unitedstates/python-us
 # Titles w/ thanks to https://github.com/nytimes/emphasis and @donohoe
 abbr_capped = "|".join([
-    "ala|ariz|ark|calif|colo|conn|del|fla|ga|ill|ind|kan|ky|la|md|mass|mich|minn|miss|mo|mont|neb|nev|okla|ore|pa|tenn|vt|va|wash|wis|wyo", # States
+    "ala|ariz|ark|calif|colo|conn|del|fla|ga|ill|ind|kan|ky|la|md|mass|mich|"
+    "minn|miss|mo|mont|neb|nev|okla|ore|pa|tenn|vt|va|wash|wis|wyo",
+    # States
     "u.s",
-    "mr|ms|mrs|msr|dr|gov|pres|sen|sens|rep|reps|prof|gen|messrs|col|sr|jf|sgt|mgr|fr|rev|jr|snr|atty|supt", # Titles
-    "ave|blvd|st|rd|hwy", # Streets
-    "jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec", # Months
+    "mr|ms|mrs|msr|dr|gov|pres|sen|sens|rep|reps|prof|gen|messrs|col|sr|jf|"
+    "sgt|mgr|fr|rev|jr|snr|atty|supt",
+    # Titles
+    "ave|blvd|st|rd|hwy",  # Streets
+    "jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec",  # Months
 ]).split("|")
 
 abbr_lowercase = "etc|v|vs|viz|al|pct".split("|")
 
+
 def is_abbreviation(dotted_word):
     clipped = dotted_word[:-1]
     if re.match(uppercase_letter_pat, clipped[0]):
-        if len(clipped) == 1: # Initial
+        if len(clipped) == 1:  # Initial
             return True
         elif clipped.lower() in abbr_capped:
             return True
         else:
             return False
     else:
-        if clipped in abbr_lowercase: return True
-        else: return False
+        if clipped in abbr_lowercase:
+            return True
+        else:
+            return False
+
 
 def is_sentence_ender(word):
-    if re.match(initialism_pat, word) is not None: return False
-    if word[-1] in [ "?", "!" ]:
+    if re.match(initialism_pat, word) is not None:
+        return False
+    if word[-1] in ["?", "!"]:
         return True
     if len(re.sub(r"[^A-Z]", "", word)) > 1:
         return True
@@ -38,16 +48,18 @@ def is_sentence_ender(word):
         return True
     return False
 
+
 def split_into_sentences(text):
     potential_end_pat = re.compile(r"".join([
-        r"([\w\.'’&\]\)]+[\.\?!])", # A word that ends with punctuation
-        r"([‘’“”'\"\)\]]*)", # Followed by optional quote/parens/etc
-        r"(\s+(?![a-z\-–—]))", # Followed by whitespace + non-(lowercase or dash)
-        ]), re.U)
+        r"([\w\.'’&\]\)]+[\.\?!])",  # A word that ends with punctuation
+        r"([‘’“”'\"\)\]]*)",  # Followed by optional quote/parens/etc
+        r"(\s+(?![a-z\-–—]))",
+        # Followed by whitespace + non-(lowercase or dash)
+    ]), re.U)
     dot_iter = re.finditer(potential_end_pat, text)
-    end_indices = [ (x.start() + len(x.group(1)) + len(x.group(2)))
-        for x in dot_iter
-        if is_sentence_ender(x.group(1)) ]
+    end_indices = [(x.start() + len(x.group(1)) + len(x.group(2)))
+                   for x in dot_iter
+                   if is_sentence_ender(x.group(1))]
     spans = zip([None] + end_indices, end_indices + [None])
-    sentences = [ text[start:end].strip() for start, end in spans ]
+    sentences = [text[start:end].strip() for start, end in spans]
     return sentences

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -2,72 +2,80 @@ import re
 import json
 import random
 from .splitters import split_into_sentences
-from .chain import Chain, BEGIN, END
+from .chain import Chain, BEGIN
 from unidecode import unidecode
 
 DEFAULT_MAX_OVERLAP_RATIO = 0.7
 DEFAULT_MAX_OVERLAP_TOTAL = 15
 DEFAULT_TRIES = 10
 
+
 class ParamError(Exception):
     pass
 
-class Text:
 
+class Text:
     reject_pat = re.compile(r"(^')|('$)|\s'|'\s|[\"(\(\)\[\])]")
 
-    def __init__(self, input_text, state_size=2, chain=None, parsed_sentences=None, retain_original=True, well_formed=True, reject_reg=''):
+    def __init__(self, input_text, state_size=2, chain=None,
+                 parsed_sentences=None, retain_original=True, well_formed=True,
+                 reject_reg=''):
         """
         input_text: A string.
-        state_size: An integer, indicating the number of words in the model's state.
-        chain: A trained markovify.Chain instance for this text, if pre-processed.
+        state_size: An integer, indicating the number of words in the model's
+            state.
+        chain: A trained markovify.Chain instance for this text, if
+            pre-processed.
         parsed_sentences: A list of lists, where each outer list is a "run"
-              of the process (e.g. a single sentence), and each inner list
-              contains the steps (e.g. words) in the run. If you want to simulate
-              an infinite process, you can come very close by passing just one, very
-              long run.
+            of the process (e.g. a single sentence), and each inner list
+            contains the steps (e.g. words) in the run. If you want to simulate
+            an infinite process, you can come very close by passing just one,
+            very long run.
         retain_original: Indicates whether to keep the original corpus.
-        well_formed: Indicates whether sentences should be well-formed, preventing
-              unmatched quotes, parenthesis by default, or a custom regular expression
-              can be provided.
-        reject_reg: If well_formed is True, this can be provided to override the
-              standard rejection pattern.
+        well_formed: Indicates whether sentences should be well-formed,
+            preventing unmatched quotes, parenthesis by default, or a custom
+            regular expression can be provided.
+        reject_reg: If well_formed is True, this can be provided to override
+            the standard rejection pattern.
         """
 
         self.well_formed = well_formed
         if well_formed and reject_reg != '':
             self.reject_pat = re.compile(reject_reg)
 
-        can_make_sentences = parsed_sentences is not None or input_text is not None
+        can_make_sentences = (
+                    parsed_sentences is not None or input_text is not None)
         self.retain_original = retain_original and can_make_sentences
         self.state_size = state_size
 
         if self.retain_original:
-            self.parsed_sentences = parsed_sentences or list(self.generate_corpus(input_text))
+            self.parsed_sentences = parsed_sentences or list(
+                self.generate_corpus(input_text))
 
             # Rejoined text lets us assess the novelty of generated sentences
-            self.rejoined_text = self.sentence_join(map(self.word_join, self.parsed_sentences))
+            self.rejoined_text = self.sentence_join(
+                map(self.word_join, self.parsed_sentences))
             self.chain = chain or Chain(self.parsed_sentences, state_size)
         else:
             if not chain:
                 parsed = parsed_sentences or self.generate_corpus(input_text)
             self.chain = chain or Chain(parsed, state_size)
 
-    def compile(self, inplace = False):
+    def compile(self, inplace=False):
         if inplace:
-            self.chain.compile(inplace = True)
+            self.chain.compile(inplace=True)
             return self
-        cchain = self.chain.compile(inplace = False)
+        cchain = self.chain.compile(inplace=False)
         psent = None
         if hasattr(self, 'parsed_sentences'):
             psent = self.parsed_sentences
-        return Text(None, \
-                    state_size = self.state_size, \
-                    chain = cchain, \
-                    parsed_sentences = psent, \
-                    retain_original = self.retain_original, \
-                    well_formed = self.well_formed, \
-                    reject_reg = self.reject_pat)
+        return Text(None,
+                    state_size=self.state_size,
+                    chain=cchain,
+                    parsed_sentences=psent,
+                    retain_original=self.retain_original,
+                    well_formed=self.well_formed,
+                    reject_reg=self.reject_pat)
 
     def to_dict(self):
         """
@@ -76,7 +84,8 @@ class Text:
         return {
             "state_size": self.state_size,
             "chain": self.chain.to_json(),
-            "parsed_sentences": self.parsed_sentences if self.retain_original else None
+            "parsed_sentences": (
+                self.parsed_sentences if self.retain_original else None)
         }
 
     def to_json(self):
@@ -104,20 +113,23 @@ class Text:
         """
         return split_into_sentences(text)
 
-    def sentence_join(self, sentences):
+    @staticmethod
+    def sentence_join(sentences):
         """
         Re-joins a list of sentences into the full text.
         """
         return " ".join(sentences)
 
     word_split_pattern = re.compile(r"\s+")
+
     def word_split(self, sentence):
         """
         Splits a sentence into a list of words.
         """
         return re.split(self.word_split_pattern, sentence)
 
-    def word_join(self, words):
+    @staticmethod
+    def word_join(words):
         """
         Re-joins a list of words into a sentence.
         """
@@ -129,11 +141,13 @@ class Text:
         the type of punctuation that would look strange on its own
         in a randomly-generated sentence.
         """
-        if len(sentence.strip()) == 0: return False
+        if len(sentence.strip()) == 0:
+            return False
         # Decode unicode, mainly to normalize fancy quotation marks
         decoded = unidecode(sentence)
         # Sentence shouldn't contain problematic characters
-        if self.well_formed and self.reject_pat.search(decoded): return False
+        if self.well_formed and self.reject_pat.search(decoded):
+            return False
         return True
 
     def generate_corpus(self, text):
@@ -152,7 +166,8 @@ class Text:
         runs = map(self.word_split, passing)
         return runs
 
-    def test_sentence_output(self, words, max_overlap_ratio, max_overlap_total):
+    def test_sentence_output(self, words, max_overlap_ratio,
+                             max_overlap_total):
         """
         Given a generated list of words, accept or reject it. This one rejects
         sentences that too closely match the original text, namely those that
@@ -165,7 +180,7 @@ class Text:
         overlap_max = min(max_overlap_total, overlap_ratio)
         overlap_over = overlap_max + 1
         gram_count = max((len(words) - overlap_max), 1)
-        grams = [ words[i:i+overlap_over] for i in range(gram_count) ]
+        grams = [words[i:i + overlap_over] for i in range(gram_count)]
         for g in grams:
             gram_joined = self.word_join(g)
             if gram_joined in self.rejoined_text:
@@ -175,20 +190,20 @@ class Text:
     def make_sentence(self, init_state=None, **kwargs):
         """
         Attempts `tries` (default: 10) times to generate a valid sentence,
-        based on the model and `test_sentence_output`. Passes `max_overlap_ratio`
-        and `max_overlap_total` to `test_sentence_output`.
+        based on the model and `test_sentence_output`. Passes
+        `max_overlap_ratio` and `max_overlap_total` to `test_sentence_output`.
 
         If successful, returns the sentence as a string. If not, returns None.
 
-        If `init_state` (a tuple of `self.chain.state_size` words) is not specified,
-        this method chooses a sentence-start at random, in accordance with
-        the model.
+        If `init_state` (a tuple of `self.chain.state_size` words) is not
+        specified, this method chooses a sentence-start at random, in
+        accordance with the model.
 
         If `test_output` is set as False then the `test_sentence_output` check
         will be skipped.
 
-        If `max_words` or `min_words` are specified, the word count for the sentence will be
-        evaluated against the provided limit(s).
+        If `max_words` or `min_words` are specified, the word count for the
+        sentence will be evaluated against the provided limit(s).
         """
         tries = kwargs.get('tries', DEFAULT_TRIES)
         mor = kwargs.get('max_overlap_ratio', DEFAULT_MAX_OVERLAP_RATIO)
@@ -197,7 +212,7 @@ class Text:
         max_words = kwargs.get('max_words', None)
         min_words = kwargs.get('min_words', None)
 
-        if init_state != None:
+        if init_state is not None:
             prefix = list(init_state)
             for word in prefix:
                 if word == BEGIN:
@@ -209,8 +224,10 @@ class Text:
 
         for _ in range(tries):
             words = prefix + self.chain.walk(init_state)
-            if (max_words != None and len(words) > max_words) or (min_words != None and len(words) < min_words):
-                continue # pragma: no cover # see https://github.com/nedbat/coveragepy/issues/198
+            if (max_words is not None and len(words) > max_words) or (
+                    min_words is not None and len(words) < min_words):
+                continue  # pragma: no cover
+                # see https://github.com/nedbat/coveragepy/issues/198
             if test_output and hasattr(self, "rejoined_text"):
                 if self.test_sentence_output(words, mor, mot):
                     return self.word_join(words)
@@ -220,8 +237,9 @@ class Text:
 
     def make_short_sentence(self, max_chars, min_chars=0, **kwargs):
         """
-        Tries making a sentence of no more than `max_chars` characters and optionally
-        no less than `min_chars` characters, passing **kwargs to `self.make_sentence`.
+        Tries making a sentence of no more than `max_chars` characters and
+        optionally no less than `min_chars` characters, passing **kwargs to
+        `self.make_sentence`.
         """
         tries = kwargs.get('tries', DEFAULT_TRIES)
 
@@ -235,7 +253,7 @@ class Text:
         Tries making a sentence that begins with `beginning` string,
         which should be a string of one to `self.state` words known
         to exist in the corpus.
-        
+
         If strict == True, then markovify will draw its initial inspiration
         only from sentences that start with the specified word/phrase.
 
@@ -248,27 +266,34 @@ class Text:
         word_count = len(split)
 
         if word_count == self.state_size:
-            init_states = [ split ]
+            init_states = [split]
 
         elif 0 < word_count < self.state_size:
             if strict:
-                init_states = [ (BEGIN,) * (self.state_size - word_count) + split ]
+                init_states = [
+                    (BEGIN,) * (self.state_size - word_count) + split]
 
             else:
-                init_states = [ key for key in self.chain.model.keys()
-                    # check for starting with begin as well ordered lists
-                    if tuple(filter(lambda x: x != BEGIN, key))[:word_count] == split ]
+                init_states = [key for key in self.chain.model.keys()
+                               # check for starting with begin
+                               # as well ordered lists
+                               if tuple(filter(lambda x: x != BEGIN, key))[
+                                  :word_count] == split]
 
                 random.shuffle(init_states)
         else:
-            err_msg = "`make_sentence_with_start` for this model requires a string containing 1 to {} words. Yours has {}: {}".format(self.state_size, word_count, str(split))
+            err_msg = (
+                f"`make_sentence_with_start` for this model requires a string "
+                f"containing 1 to {self.state_size} words. "
+                f"Yours has {word_count}: {split}")
             raise ParamError(err_msg)
 
         for init_state in init_states:
             output = self.make_sentence(init_state, **kwargs)
             if output is not None:
                 return output
-        err_msg = f"`make_sentence_with_start` can't find sentence beginning with {beginning}"
+        err_msg = (f"`make_sentence_with_start` can't find sentence "
+                   f"beginning with {beginning}")
         raise ParamError(err_msg)
 
     @classmethod
@@ -278,13 +303,16 @@ class Text:
         If corpus is None, overlap checking won't work.
         """
         chain = Chain.from_json(chain_json)
-        return cls(corpus or None, parsed_sentences=parsed_sentences, state_size=chain.state_size, chain=chain)
+        return cls(corpus or None, parsed_sentences=parsed_sentences,
+                   state_size=chain.state_size, chain=chain)
 
 
 class NewlineText(Text):
     """
-    A (usable) example of subclassing markovify.Text. This one lets you markovify
-    text where the sentences are separated by newlines instead of ". "
+    A (usable) example of subclassing markovify.Text. This one lets you
+    markovify text where the sentences are separated by newlines
+    instead of ". "
     """
+
     def sentence_split(self, text):
         return re.split(r"\s*\n\s*", text)

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -227,7 +227,7 @@ class Text:
 
         for _ in range(tries):
             sentence = self.make_sentence(**kwargs)
-            if sentence and len(sentence) <= max_chars and len(sentence) >= min_chars:
+            if sentence and min_chars <= len(sentence) <= max_chars:
                 return sentence
 
     def make_sentence_with_start(self, beginning, strict=True, **kwargs):
@@ -250,7 +250,7 @@ class Text:
         if word_count == self.state_size:
             init_states = [ split ]
 
-        elif word_count > 0 and word_count < self.state_size:
+        elif 0 < word_count < self.state_size:
             if strict:
                 init_states = [ (BEGIN,) * (self.state_size - word_count) + split ]
 

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -176,7 +176,7 @@ class Text:
         number of words, and (b) `max_overlap_total` (default: 15).
         """
         # Reject large chunks of similarity
-        overlap_ratio = int(round(max_overlap_ratio * len(words)))
+        overlap_ratio = round(max_overlap_ratio * len(words))
         overlap_max = min(max_overlap_total, overlap_ratio)
         overlap_over = overlap_max + 1
         gram_count = max((len(words) - overlap_max), 1)

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -12,7 +12,7 @@ DEFAULT_TRIES = 10
 class ParamError(Exception):
     pass
 
-class Text(object):
+class Text:
 
     reject_pat = re.compile(r"(^')|('$)|\s'|'\s|[\"(\(\)\[\])]")
 
@@ -261,14 +261,14 @@ class Text(object):
 
                 random.shuffle(init_states)
         else:
-            err_msg = "`make_sentence_with_start` for this model requires a string containing 1 to {0} words. Yours has {1}: {2}".format(self.state_size, word_count, str(split))
+            err_msg = "`make_sentence_with_start` for this model requires a string containing 1 to {} words. Yours has {}: {}".format(self.state_size, word_count, str(split))
             raise ParamError(err_msg)
 
         for init_state in init_states:
             output = self.make_sentence(init_state, **kwargs)
             if output is not None:
                 return output
-        err_msg = "`make_sentence_with_start` can't find sentence beginning with {0}".format(beginning)
+        err_msg = f"`make_sentence_with_start` can't find sentence beginning with {beginning}"
         raise ParamError(err_msg)
 
     @classmethod

--- a/markovify/utils.py
+++ b/markovify/utils.py
@@ -1,6 +1,7 @@
 from .chain import Chain
 from .text import Text
 
+
 def get_model_dict(thing):
     if isinstance(thing, Chain):
         if thing.compiled:
@@ -15,18 +16,19 @@ def get_model_dict(thing):
     if isinstance(thing, dict):
         return thing
 
-    raise ValueError("`models` should be instances of list, dict, markovify.Chain, or markovify.Text")
+    raise ValueError("`models` should be instances of list, dict, "
+                     "markovify.Chain, or markovify.Text")
+
 
 def combine(models, weights=None):
-    if weights == None:
-        weights = [ 1 for _ in range(len(models)) ]
+    if weights is None:
+        weights = [1 for _ in range(len(models))]
 
     if len(models) != len(weights):
         raise ValueError("`models` and `weights` lengths must be equal.")
 
     model_dicts = list(map(get_model_dict, models))
-    state_sizes = [ len(list(md.keys())[0])
-        for md in model_dicts ]
+    state_sizes = [len(list(md.keys())[0]) for md in model_dicts]
 
     if len(set(state_sizes)) != 1:
         raise ValueError("All `models` must have the same state size.")

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-import sys, os
+import os
 
 NAME = "markovify"
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -14,7 +14,9 @@ with open(os.path.join(HERE, 'README.md'), encoding='utf-8') as f:
 setup(
     name="markovify",
     version=version_ns['__version__'],
-    description="A simple, extensible Markov chain generator. Uses include generating random semi-plausible sentences based on an existing text.",
+    description=("A simple, extensible Markov chain generator. Uses include "
+                 "generating random semi-plausible sentences based on an "
+                 "existing text."),
     long_description=long_description,
     long_description_content_type="text/markdown",
     classifiers=[
@@ -31,7 +33,7 @@ setup(
     author_email="jsvine@gmail.com",
     url="http://github.com/jsvine/markovify",
     license="MIT",
-    packages=find_packages(exclude=["test",]),
+    packages=find_packages(exclude=["test", ]),
     namespace_packages=[],
     include_package_data=False,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,13 @@
+from pathlib import Path
 from setuptools import setup, find_packages
-import os
 
 NAME = "markovify"
-HERE = os.path.abspath(os.path.dirname(__file__))
+HERE = Path(__file__).resolve().parent
 
 version_ns = {}
-with open(os.path.join(HERE, NAME, '__version__.py'), encoding='utf-8') as f:
-    exec(f.read(), {}, version_ns)
+exec((HERE / NAME / '__version__.py').read_text(), {}, version_ns)
 
-with open(os.path.join(HERE, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
+long_description = (HERE / 'README.md').read_text()
 
 setup(
     name="markovify",

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,2 +1,0 @@
-from . import test_basic
-from . import test_combine

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -10,7 +10,7 @@ class MarkovifyTestBase(unittest.TestCase):
     __test__ = False
 
     def test_text_too_small(self):
-        text = u"Example phrase. This is another example sentence."
+        text = "Example phrase. This is another example sentence."
         text_model = markovify.Text(text)
         assert(text_model.make_sentence() == None)
 

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -1,7 +1,11 @@
-import unittest
-import markovify
-import os
 import operator
+import unittest
+from pathlib import Path
+
+import markovify
+
+
+TEXTS = Path(__file__).resolve().parent / 'texts'
 
 
 def get_sorted(chain_json):
@@ -149,9 +153,7 @@ class MarkovifyTestBase(unittest.TestCase):
 
     @staticmethod
     def test_newline_text():
-        with open(os.path.join(os.path.dirname(__file__),
-                               "texts/senate-bills.txt")) as f:
-            model = markovify.NewlineText(f.read())
+        model = markovify.NewlineText((TEXTS / 'senate-bills.txt').read_text())
         model.make_sentence()
 
     def test_bad_corpus(self):
@@ -178,25 +180,19 @@ class MarkovifyTestBase(unittest.TestCase):
 class MarkovifyTest(MarkovifyTestBase):
     __test__ = True
 
-    with open(os.path.join(os.path.dirname(__file__),
-                           "texts/sherlock.txt")) as f:
-        sherlock_text = f.read()
-        sherlock_model = markovify.Text(sherlock_text)
-        sherlock_model_ss2 = markovify.Text(sherlock_text, state_size=2)
-        sherlock_model_ss3 = markovify.Text(sherlock_text, state_size=3)
+    sherlock_text = (TEXTS / 'sherlock.txt').read_text()
+    sherlock_model = markovify.Text(sherlock_text)
+    sherlock_model_ss2 = markovify.Text(sherlock_text, state_size=2)
+    sherlock_model_ss3 = markovify.Text(sherlock_text, state_size=3)
 
 
 class MarkovifyTestCompiled(MarkovifyTestBase):
     __test__ = True
 
-    with open(os.path.join(os.path.dirname(__file__),
-                           "texts/sherlock.txt")) as f:
-        sherlock_text = f.read()
-        sherlock_model = (markovify.Text(sherlock_text)).compile()
-        sherlock_model_ss2 = (
-            markovify.Text(sherlock_text, state_size=2)).compile()
-        sherlock_model_ss3 = (
-            markovify.Text(sherlock_text, state_size=3)).compile()
+    sherlock_text = (TEXTS / 'sherlock.txt').read_text()
+    sherlock_model = markovify.Text(sherlock_text).compile()
+    sherlock_model_ss2 = markovify.Text(sherlock_text, state_size=2).compile()
+    sherlock_model_ss3 = markovify.Text(sherlock_text, state_size=3).compile()
 
     def test_recompiling(self):
         model_recompile = self.sherlock_model.compile()
@@ -211,15 +207,13 @@ class MarkovifyTestCompiled(MarkovifyTestBase):
 class MarkovifyTestCompiledInPlace(MarkovifyTestBase):
     __test__ = True
 
-    with open(os.path.join(os.path.dirname(__file__),
-                           "texts/sherlock.txt")) as f:
-        sherlock_text = f.read()
-        sherlock_model = markovify.Text(sherlock_text)
-        sherlock_model_ss2 = markovify.Text(sherlock_text, state_size=2)
-        sherlock_model_ss3 = markovify.Text(sherlock_text, state_size=3)
-        sherlock_model.compile(inplace=True)
-        sherlock_model_ss2.compile(inplace=True)
-        sherlock_model_ss3.compile(inplace=True)
+    sherlock_text = (TEXTS / 'sherlock.txt').read_text()
+    sherlock_model = markovify.Text(sherlock_text)
+    sherlock_model_ss2 = markovify.Text(sherlock_text, state_size=2)
+    sherlock_model_ss3 = markovify.Text(sherlock_text, state_size=3)
+    sherlock_model.compile(inplace=True)
+    sherlock_model_ss2.compile(inplace=True)
+    sherlock_model_ss3.compile(inplace=True)
 
 
 if __name__ == '__main__':

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -1,113 +1,122 @@
 import unittest
 import markovify
-import sys, os
+import os
 import operator
+
 
 def get_sorted(chain_json):
     return sorted(chain_json, key=operator.itemgetter(0))
 
+
 class MarkovifyTestBase(unittest.TestCase):
     __test__ = False
 
-    def test_text_too_small(self):
+    @staticmethod
+    def test_text_too_small():
         text = "Example phrase. This is another example sentence."
         text_model = markovify.Text(text)
-        assert(text_model.make_sentence() == None)
+        assert text_model.make_sentence() is None
 
     def test_sherlock(self):
         text_model = self.sherlock_model
         sent = text_model.make_sentence()
-        assert(len(sent) != 0)
+        assert len(sent) != 0
 
     def test_json(self):
         text_model = self.sherlock_model
         json_model = text_model.to_json()
         new_text_model = markovify.Text.from_json(json_model)
         sent = new_text_model.make_sentence()
-        assert(len(sent) != 0)
+        assert len(sent) != 0
 
     def test_chain(self):
         text_model = self.sherlock_model
         chain_json = text_model.chain.to_json()
 
         stored_chain = markovify.Chain.from_json(chain_json)
-        assert(get_sorted(stored_chain.to_json()) == get_sorted(chain_json))
+        assert get_sorted(stored_chain.to_json()) == get_sorted(chain_json)
 
         new_text_model = markovify.Text.from_chain(chain_json)
-        assert(get_sorted(new_text_model.chain.to_json()) == get_sorted(chain_json))
+        assert get_sorted(new_text_model.chain.to_json()) == get_sorted(
+            chain_json)
 
         sent = new_text_model.make_sentence()
-        assert(len(sent) != 0)
+        assert len(sent) != 0
 
     def test_make_sentence_with_start(self):
         text_model = self.sherlock_model
         start_str = "Sherlock Holmes"
         sent = text_model.make_sentence_with_start(start_str)
-        assert(sent != None)
-        assert(start_str == sent[:len(start_str)])
+        assert sent is not None
+        assert start_str == sent[:len(start_str)]
 
     def test_make_sentence_with_start_one_word(self):
         text_model = self.sherlock_model
         start_str = "Sherlock"
         sent = text_model.make_sentence_with_start(start_str)
-        assert(sent != None)
-        assert(start_str == sent[:len(start_str)])
+        assert sent is not None
+        assert start_str == sent[:len(start_str)]
 
-    def test_make_sentence_with_start_one_word_that_doesnt_begin_a_sentence(self):
+    def test_make_sentence_with_start_one_word_that_doesnt_begin_a_sentence(
+            self):
         text_model = self.sherlock_model
         start_str = "dog"
-        with self.assertRaises(KeyError) as context:
-            sent = text_model.make_sentence_with_start(start_str)
+        with self.assertRaises(KeyError):
+            text_model.make_sentence_with_start(start_str)
 
     def test_make_sentence_with_word_not_at_start_of_sentence(self):
         text_model = self.sherlock_model
         start_str = "dog"
         sent = text_model.make_sentence_with_start(start_str, strict=False)
-        assert(sent != None)
-        assert(start_str == sent[:len(start_str)])
+        assert sent is not None
+        assert start_str == sent[:len(start_str)]
 
     def test_make_sentence_with_words_not_at_start_of_sentence(self):
         text_model = self.sherlock_model_ss3
         # " I was " has 128 matches in sherlock.txt
         # " was I " has 2 matches in sherlock.txt
         start_str = "was I"
-        sent = text_model.make_sentence_with_start(start_str, strict=False, tries=50)
-        assert(sent != None)
-        assert(start_str == sent[:len(start_str)])
+        sent = text_model.make_sentence_with_start(start_str, strict=False,
+                                                   tries=50)
+        assert sent is not None
+        assert start_str == sent[:len(start_str)]
 
     def test_make_sentence_with_words_not_at_start_of_sentence_miss(self):
         text_model = self.sherlock_model_ss3
         start_str = "was werewolf"
         with self.assertRaises(markovify.text.ParamError):
-            sent = text_model.make_sentence_with_start(start_str, strict=False, tries=50)
+            text_model.make_sentence_with_start(start_str, strict=False,
+                                                tries=50)
 
-    def test_make_sentence_with_words_not_at_start_of_sentence_of_state_size(self):
+    def test_make_sentence_with_words_not_at_start_of_sentence_of_state_size(
+            self):
         text_model = self.sherlock_model_ss2
         start_str = "was I"
-        sent = text_model.make_sentence_with_start(start_str, strict=False, tries=50)
-        assert(sent != None)
-        assert(start_str == sent[:len(start_str)])
+        sent = text_model.make_sentence_with_start(start_str, strict=False,
+                                                   tries=50)
+        assert sent is not None
+        assert start_str == sent[:len(start_str)]
 
     def test_make_sentence_with_words_to_many(self):
         text_model = self.sherlock_model
         start_str = "dog is good"
-        with self.assertRaises(markovify.text.ParamError) as context:
-            sent = text_model.make_sentence_with_start(start_str, strict=False)
+        with self.assertRaises(markovify.text.ParamError):
+            text_model.make_sentence_with_start(start_str, strict=False)
 
     def test_make_sentence_with_start_three_words(self):
         start_str = "Sherlock Holmes was"
         text_model = self.sherlock_model
         try:
             text_model.make_sentence_with_start(start_str)
-            assert(False)
+            assert False
         except markovify.text.ParamError:
-            assert(True)
-	
-        with self.assertRaises(Exception) as context:
+            assert True
+
+        with self.assertRaises(Exception):
             text_model.make_sentence_with_start(start_str)
         text_model = self.sherlock_model_ss3
         sent = text_model.make_sentence_with_start("Sherlock", tries=50)
-        assert(markovify.chain.BEGIN not in sent)
+        assert markovify.chain.BEGIN not in sent
 
     def test_short_sentence(self):
         text_model = self.sherlock_model
@@ -138,66 +147,80 @@ class MarkovifyTestBase(unittest.TestCase):
         sent = text_model.make_sentence(min_words=5)
         assert len(sent.split(' ')) >= 5
 
-    def test_newline_text(self):
-        with open(os.path.join(os.path.dirname(__file__), "texts/senate-bills.txt")) as f:
+    @staticmethod
+    def test_newline_text():
+        with open(os.path.join(os.path.dirname(__file__),
+                               "texts/senate-bills.txt")) as f:
             model = markovify.NewlineText(f.read())
         model.make_sentence()
 
     def test_bad_corpus(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(Exception):
             markovify.Chain(corpus="testing, testing", state_size=2)
 
     def test_bad_json(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(Exception):
             markovify.Chain.from_json(1)
 
     def test_custom_regex(self):
-        with self.assertRaises(Exception) as context:
-            model = markovify.NewlineText('This sentence contains a custom bad character: #.', reject_reg=r'#')
+        with self.assertRaises(Exception):
+            markovify.NewlineText(
+                'This sentence contains a custom bad character: #.',
+                reject_reg=r'#')
 
-        with self.assertRaises(Exception) as context:
-            model = markovify.NewlineText('This sentence (would normall fail')
+        with self.assertRaises(Exception):
+            markovify.NewlineText('This sentence (would normall fail')
 
-        model = markovify.NewlineText('This sentence (would normall fail', well_formed = False)
+        markovify.NewlineText('This sentence (would normall fail',
+                              well_formed=False)
+
 
 class MarkovifyTest(MarkovifyTestBase):
     __test__ = True
 
-    with open(os.path.join(os.path.dirname(__file__), "texts/sherlock.txt")) as f:
+    with open(os.path.join(os.path.dirname(__file__),
+                           "texts/sherlock.txt")) as f:
         sherlock_text = f.read()
         sherlock_model = markovify.Text(sherlock_text)
-        sherlock_model_ss2 = markovify.Text(sherlock_text, state_size = 2)
-        sherlock_model_ss3 = markovify.Text(sherlock_text, state_size = 3)
+        sherlock_model_ss2 = markovify.Text(sherlock_text, state_size=2)
+        sherlock_model_ss3 = markovify.Text(sherlock_text, state_size=3)
+
 
 class MarkovifyTestCompiled(MarkovifyTestBase):
     __test__ = True
 
-    with open(os.path.join(os.path.dirname(__file__), "texts/sherlock.txt")) as f:
+    with open(os.path.join(os.path.dirname(__file__),
+                           "texts/sherlock.txt")) as f:
         sherlock_text = f.read()
         sherlock_model = (markovify.Text(sherlock_text)).compile()
-        sherlock_model_ss2 = (markovify.Text(sherlock_text, state_size = 2)).compile()
-        sherlock_model_ss3 = (markovify.Text(sherlock_text, state_size = 3)).compile()
+        sherlock_model_ss2 = (
+            markovify.Text(sherlock_text, state_size=2)).compile()
+        sherlock_model_ss3 = (
+            markovify.Text(sherlock_text, state_size=3)).compile()
 
     def test_recompiling(self):
         model_recompile = self.sherlock_model.compile()
         sent = model_recompile.make_sentence()
-        assert(len(sent) != 0)
+        assert len(sent) != 0
 
-        model_recompile.compile(inplace = True)
+        model_recompile.compile(inplace=True)
         sent = model_recompile.make_sentence()
-        assert(len(sent) != 0)
+        assert len(sent) != 0
+
 
 class MarkovifyTestCompiledInPlace(MarkovifyTestBase):
     __test__ = True
 
-    with open(os.path.join(os.path.dirname(__file__), "texts/sherlock.txt")) as f:
+    with open(os.path.join(os.path.dirname(__file__),
+                           "texts/sherlock.txt")) as f:
         sherlock_text = f.read()
         sherlock_model = markovify.Text(sherlock_text)
-        sherlock_model_ss2 = markovify.Text(sherlock_text, state_size = 2)
-        sherlock_model_ss3 = markovify.Text(sherlock_text, state_size = 3)
-        sherlock_model.compile(inplace = True)
-        sherlock_model_ss2.compile(inplace = True)
-        sherlock_model_ss3.compile(inplace = True)
+        sherlock_model_ss2 = markovify.Text(sherlock_text, state_size=2)
+        sherlock_model_ss3 = markovify.Text(sherlock_text, state_size=3)
+        sherlock_model.compile(inplace=True)
+        sherlock_model_ss2.compile(inplace=True)
+        sherlock_model_ss3.compile(inplace=True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_combine.py
+++ b/test/test_combine.py
@@ -1,18 +1,21 @@
-import unittest
-import markovify
-import os
 import operator
+import unittest
+from pathlib import Path
+
+import markovify
+
+
+TEXTS = Path(__file__).resolve().parent / 'texts'
 
 
 def get_sorted(chain_json):
     return sorted(chain_json, key=operator.itemgetter(0))
 
 
-with open(os.path.join(os.path.dirname(__file__), "texts/sherlock.txt")) as f:
-    sherlock = f.read()
-    sherlock_model = markovify.Text(sherlock)
-    sherlock_model_no_retain = markovify.Text(sherlock, retain_original=False)
-    sherlock_model_compiled = sherlock_model.compile()
+sherlock_text = (TEXTS / 'sherlock.txt').read_text()
+sherlock_model = markovify.Text(sherlock_text)
+sherlock_model_no_retain = markovify.Text(sherlock_text, retain_original=False)
+sherlock_model_compiled = sherlock_model.compile()
 
 
 class MarkovifyTest(unittest.TestCase):
@@ -55,14 +58,14 @@ class MarkovifyTest(unittest.TestCase):
 
     def test_mismatched_state_sizes(self):
         with self.assertRaises(Exception):
-            text_model_a = markovify.Text(sherlock, state_size=2)
-            text_model_b = markovify.Text(sherlock, state_size=3)
+            text_model_a = markovify.Text(sherlock_text, state_size=2)
+            text_model_b = markovify.Text(sherlock_text, state_size=3)
             markovify.combine([text_model_a, text_model_b])
 
     def test_mismatched_model_types(self):
         with self.assertRaises(Exception):
             text_model_a = sherlock_model
-            text_model_b = markovify.NewlineText(sherlock)
+            text_model_b = markovify.NewlineText(sherlock_text)
             markovify.combine([text_model_a, text_model_b])
 
     def test_compiled_model_fail(self):

--- a/test/test_combine.py
+++ b/test/test_combine.py
@@ -1,10 +1,12 @@
 import unittest
 import markovify
-import sys, os
+import os
 import operator
+
 
 def get_sorted(chain_json):
     return sorted(chain_json, key=operator.itemgetter(0))
+
 
 with open(os.path.join(os.path.dirname(__file__), "texts/sherlock.txt")) as f:
     sherlock = f.read()
@@ -12,82 +14,91 @@ with open(os.path.join(os.path.dirname(__file__), "texts/sherlock.txt")) as f:
     sherlock_model_no_retain = markovify.Text(sherlock, retain_original=False)
     sherlock_model_compiled = sherlock_model.compile()
 
+
 class MarkovifyTest(unittest.TestCase):
 
-    def test_simple(self):
+    @staticmethod
+    def test_simple():
         text_model = sherlock_model
-        combo = markovify.combine([ text_model, text_model ], [ 0.5, 0.5 ])
-        assert(combo.chain.model == text_model.chain.model)
+        combo = markovify.combine([text_model, text_model], [0.5, 0.5])
+        assert combo.chain.model == text_model.chain.model
 
-    def test_double_weighted(self):
+    @staticmethod
+    def test_double_weighted():
         text_model = sherlock_model
-        combo = markovify.combine([ text_model, text_model ])
-        assert(combo.chain.model != text_model.chain.model)
+        combo = markovify.combine([text_model, text_model])
+        assert combo.chain.model != text_model.chain.model
 
-    def test_combine_chains(self):
+    @staticmethod
+    def test_combine_chains():
         chain = sherlock_model.chain
-        combo = markovify.combine([ chain, chain ])
+        markovify.combine([chain, chain])
 
-    def test_combine_dicts(self):
+    @staticmethod
+    def test_combine_dicts():
         _dict = sherlock_model.chain.model
-        combo = markovify.combine([ _dict, _dict ])
+        markovify.combine([_dict, _dict])
 
-    def test_combine_lists(self):
+    @staticmethod
+    def test_combine_lists():
         _list = list(sherlock_model.chain.model.items())
-        combo = markovify.combine([ _list, _list ])
+        markovify.combine([_list, _list])
 
     def test_bad_types(self):
-        with self.assertRaises(Exception) as context:
-            combo = markovify.combine([ "testing", "testing" ])
+        with self.assertRaises(Exception):
+            markovify.combine(["testing", "testing"])
 
     def test_bad_weights(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(Exception):
             text_model = sherlock_model
-            combo = markovify.combine([ text_model, text_model ], [ 0.5  ])
+            markovify.combine([text_model, text_model], [0.5])
 
     def test_mismatched_state_sizes(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(Exception):
             text_model_a = markovify.Text(sherlock, state_size=2)
             text_model_b = markovify.Text(sherlock, state_size=3)
-            combo = markovify.combine([ text_model_a, text_model_b ])
+            markovify.combine([text_model_a, text_model_b])
 
     def test_mismatched_model_types(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(Exception):
             text_model_a = sherlock_model
             text_model_b = markovify.NewlineText(sherlock)
-            combo = markovify.combine([ text_model_a, text_model_b ])
+            markovify.combine([text_model_a, text_model_b])
 
     def test_compiled_model_fail(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(Exception):
             model_a = sherlock_model
             model_b = sherlock_model_compiled
-            combo = markovify.combine([ model_a, model_b ])
+            markovify.combine([model_a, model_b])
 
     def test_compiled_chain_fail(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(Exception):
             model_a = sherlock_model.chain
             model_b = sherlock_model_compiled.chain
-            combo = markovify.combine([ model_a, model_b ])
+            markovify.combine([model_a, model_b])
 
-    def test_combine_no_retain(self):
+    @staticmethod
+    def test_combine_no_retain():
         text_model = sherlock_model_no_retain
-        combo = markovify.combine([ text_model, text_model ])
-        assert(not combo.retain_original)
+        combo = markovify.combine([text_model, text_model])
+        assert not combo.retain_original
 
-    def test_combine_retain_on_no_retain(self):
+    @staticmethod
+    def test_combine_retain_on_no_retain():
         text_model_a = sherlock_model_no_retain
         text_model_b = sherlock_model
-        combo = markovify.combine([ text_model_a, text_model_b ])
-        assert(combo.retain_original)
-        assert(combo.parsed_sentences == text_model_b.parsed_sentences)
+        combo = markovify.combine([text_model_a, text_model_b])
+        assert combo.retain_original
+        assert combo.parsed_sentences == text_model_b.parsed_sentences
 
-    def test_combine_no_retain_on_retain(self):
+    @staticmethod
+    def test_combine_no_retain_on_retain():
         text_model_a = sherlock_model_no_retain
         text_model_b = sherlock_model
-        combo = markovify.combine([ text_model_b, text_model_a ])
-        assert(combo.retain_original)
-        assert(combo.parsed_sentences == text_model_b.parsed_sentences)
+        combo = markovify.combine([text_model_b, text_model_a])
+        assert combo.retain_original
+        assert combo.parsed_sentences == text_model_b.parsed_sentences
+
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/test/test_itertext.py
+++ b/test/test_itertext.py
@@ -1,34 +1,34 @@
 import unittest
+from pathlib import Path
+
 import markovify
-import os
+
+
+TEXTS = Path(__file__).resolve().parent / 'texts'
 
 
 class MarkovifyTest(unittest.TestCase):
 
     @staticmethod
     def test_simple():
-        with open(os.path.join(os.path.dirname(__file__),
-                               "texts/sherlock.txt")) as f:
-            sherlock_model = markovify.Text(f)
+        sherlock_model = markovify.Text((TEXTS / 'sherlock.txt').read_text())
         sent = sherlock_model.make_sentence()
         assert sent is not None
         assert len(sent) != 0
 
     @staticmethod
     def test_without_retaining():
-        with open(os.path.join(os.path.dirname(__file__),
-                               "texts/senate-bills.txt")) as f:
-            senate_model = markovify.Text(f, retain_original=False)
+        senate_model = markovify.Text((TEXTS / 'senate-bills.txt').read_text(),
+                                      retain_original=False)
         sent = senate_model.make_sentence()
         assert sent is not None
         assert len(sent) != 0
 
     @staticmethod
     def test_from_json_without_retaining():
-        with open(os.path.join(os.path.dirname(__file__),
-                               "texts/senate-bills.txt")) as f:
-            original_model = markovify.Text(f, retain_original=False)
-        d = original_model.to_json()
+        senate_model = markovify.Text((TEXTS / 'senate-bills.txt').read_text(),
+                                      retain_original=False)
+        d = senate_model.to_json()
         new_model = markovify.Text.from_json(d)
         sent = new_model.make_sentence()
         assert sent is not None
@@ -37,11 +37,9 @@ class MarkovifyTest(unittest.TestCase):
     @staticmethod
     def test_from_mult_files_without_retaining():
         models = []
-        for (dirpath, _, filenames) in os.walk(
-                os.path.join(os.path.dirname(__file__), "texts")):
-            for filename in filenames:
-                with open(os.path.join(dirpath, filename)) as f:
-                    models.append(markovify.Text(f, retain_original=False))
+        for path in TEXTS.glob('*.txt'):
+            models.append(markovify.Text(path.read_text(),
+                                         retain_original=False))
         combined_model = markovify.combine(models)
         sent = combined_model.make_sentence()
         assert sent is not None

--- a/test/test_itertext.py
+++ b/test/test_itertext.py
@@ -1,26 +1,32 @@
 import unittest
 import markovify
-import sys, os
-import operator
+import os
+
 
 class MarkovifyTest(unittest.TestCase):
 
-    def test_simple(self):
-        with open(os.path.join(os.path.dirname(__file__), "texts/sherlock.txt")) as f:
+    @staticmethod
+    def test_simple():
+        with open(os.path.join(os.path.dirname(__file__),
+                               "texts/sherlock.txt")) as f:
             sherlock_model = markovify.Text(f)
         sent = sherlock_model.make_sentence()
         assert sent is not None
         assert len(sent) != 0
 
-    def test_without_retaining(self):
-        with open(os.path.join(os.path.dirname(__file__), "texts/senate-bills.txt")) as f:
+    @staticmethod
+    def test_without_retaining():
+        with open(os.path.join(os.path.dirname(__file__),
+                               "texts/senate-bills.txt")) as f:
             senate_model = markovify.Text(f, retain_original=False)
         sent = senate_model.make_sentence()
         assert sent is not None
         assert len(sent) != 0
 
-    def test_from_json_without_retaining(self):
-        with open(os.path.join(os.path.dirname(__file__), "texts/senate-bills.txt")) as f:
+    @staticmethod
+    def test_from_json_without_retaining():
+        with open(os.path.join(os.path.dirname(__file__),
+                               "texts/senate-bills.txt")) as f:
             original_model = markovify.Text(f, retain_original=False)
         d = original_model.to_json()
         new_model = markovify.Text.from_json(d)
@@ -28,9 +34,11 @@ class MarkovifyTest(unittest.TestCase):
         assert sent is not None
         assert len(sent) != 0
 
-    def test_from_mult_files_without_retaining(self):
+    @staticmethod
+    def test_from_mult_files_without_retaining():
         models = []
-        for (dirpath, _, filenames) in os.walk(os.path.join(os.path.dirname(__file__), "texts")):
+        for (dirpath, _, filenames) in os.walk(
+                os.path.join(os.path.dirname(__file__), "texts")):
             for filename in filenames:
                 with open(os.path.join(dirpath, filename)) as f:
                     models.append(markovify.Text(f, retain_original=False))
@@ -39,7 +47,6 @@ class MarkovifyTest(unittest.TestCase):
         assert sent is not None
         assert len(sent) != 0
 
+
 if __name__ == '__main__':
     unittest.main()
-
-


### PR DESCRIPTION
Now that we're at Python 3.6+, we can modernize the code and add f-strings, `pathlib.Path` and other Python3 features.

Next steps would be to convert the tests to `pytest`. What do you think?