### PR TITLE
Add caching for non-strict make_sentence_with_start

### DIFF
--- a/markovify/text.py
+++ b/markovify/text.py
@@ -301,11 +301,11 @@ class Text:
     @functools.lru_cache(maxsize=1)
     def find_init_states_from_chain(self, word_count, split):
         """
-        Find all chains that begin with the split, when `self.make_sentence_with_start` 
+        Find all chains that begin with the split when `self.make_sentence_with_start` 
         is called with strict == False. 
 
-        This is a very expensive opeartion, so lru_cache caches the results of 
-        the latest query, in case the `self.make_sentence_with_start` is called 
+        This is a very expensive operation, so lru_cache caches the results of 
+        the latest query in case `self.make_sentence_with_start` is called 
         repeatedly with the same beginning string. 
         """
         return [

--- a/markovify/text.py
+++ b/markovify/text.py
@@ -16,7 +16,6 @@ class ParamError(Exception):
 
 
 class Text:
-
     reject_pat = re.compile(r"(^')|('$)|\s'|'\s|[\"(\(\)\[\])]")
 
     def __init__(
@@ -278,7 +277,7 @@ class Text:
                 init_states = [(BEGIN,) * (self.state_size - word_count) + split]
 
             else:
-                init_states = self.find_init_states_from_chain(word_count, split)
+                init_states = self.find_init_states_from_chain(split)
 
                 random.shuffle(init_states)
         else:
@@ -299,15 +298,16 @@ class Text:
         raise ParamError(err_msg)
 
     @functools.lru_cache(maxsize=1)
-    def find_init_states_from_chain(self, word_count, split):
+    def find_init_states_from_chain(self, split):
         """
-        Find all chains that begin with the split when `self.make_sentence_with_start` 
-        is called with strict == False. 
+        Find all chains that begin with the split when `self.make_sentence_with_start`
+        is called with strict == False.
 
-        This is a very expensive operation, so lru_cache caches the results of 
-        the latest query in case `self.make_sentence_with_start` is called 
-        repeatedly with the same beginning string. 
+        This is a very expensive operation, so lru_cache caches the results of
+        the latest query in case `self.make_sentence_with_start` is called
+        repeatedly with the same beginning string.
         """
+        word_count = len(split)
         return [
             key
             for key in self.chain.model.keys()

--- a/markovify/utils.py
+++ b/markovify/utils.py
@@ -52,6 +52,7 @@ def combine(models, weights=None):
     if isinstance(ret_inst, Chain):
         return Chain.from_json(c)
     if isinstance(ret_inst, Text):
+        ret_inst.find_init_states_from_chain.cache_clear()
         if any(m.retain_original for m in models):
             combined_sentences = []
             for m in models:

--- a/test/test_itertext.py
+++ b/test/test_itertext.py
@@ -35,7 +35,7 @@ class MarkovifyTest(unittest.TestCase):
 
     def test_from_mult_files_without_retaining(self):
         models = []
-        for (dirpath, _, filenames) in os.walk(
+        for dirpath, _, filenames in os.walk(
             os.path.join(os.path.dirname(__file__), "texts")
         ):
             for filename in filenames:


### PR DESCRIPTION
Looping through all of the keys in the chain can be a very expensive operation, if the corpus is large. It's OK when done once, but when calling `make_sentence_with_start(beginning, strict=False)` repeatedly with the same beginning, it becomes a bottleneck. 

For example, when calling it 1000 times with a chain of 100 000 keys (~12k tweet-sized input texts), it took me about 40 seconds to generate the results. With caching, it took a fraction of a second. 

Not sure if caching is desired in all cases though. At least it should be cleared when combining models. 