### PR TITLE
add reference to higher-order Markov chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Notes:
 
 ## Advanced Usage
 
-### Specifying the model's state size
+### Specifying the model's state size (aka the *order* of higher-order Markov chains)
 
 State size is a number of words the probability of a next word depends on.
 


### PR DESCRIPTION
Currently, one cannot just search for "order" to figure out whether markovify supports higher-order Markov chains or not. This PR is supposed to make this easier to find out.