### PR TITLE
Add type annotations

### DIFF
--- a/markovify/splitters.py
+++ b/markovify/splitters.py
@@ -1,4 +1,5 @@
 import re
+from typing import List
 
 uppercase_letter_pat = re.compile(r"^[A-Z]$", re.UNICODE)
 initialism_pat = re.compile(r"^[A-Za-z0-9]{1,2}(\.[A-Za-z0-9]{1,2})+\.$", re.UNICODE)
@@ -22,7 +23,7 @@ abbr_capped = "|".join(
 abbr_lowercase = "etc|v|vs|viz|al|pct".split("|")
 
 
-def is_abbreviation(dotted_word):
+def is_abbreviation(dotted_word: str) -> bool:
     clipped = dotted_word[:-1]
     if re.match(uppercase_letter_pat, clipped[0]):
         if len(clipped) == 1:  # Initial
@@ -38,7 +39,7 @@ def is_abbreviation(dotted_word):
             return False
 
 
-def is_sentence_ender(word):
+def is_sentence_ender(word: str) -> bool:
     if re.match(initialism_pat, word) is not None:
         return False
     if word[-1] in ["?", "!"]:
@@ -50,7 +51,7 @@ def is_sentence_ender(word):
     return False
 
 
-def split_into_sentences(text):
+def split_into_sentences(text: str) -> List[str]:
     potential_end_pat = re.compile(
         r"".join(
             [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ flake8
 pytest
 pytest-cov
 coveralls
+typing_extensions

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -11,24 +11,24 @@ def get_sorted(chain_json):
 class MarkovifyTestBase(unittest.TestCase):
     __test__ = False
 
-    def test_text_too_small(self):
+    def test_text_too_small(self) -> None:
         text = "Example phrase. This is another example sentence."
         text_model = markovify.Text(text)
         assert text_model.make_sentence() is None
 
-    def test_sherlock(self):
+    def test_sherlock(self) -> None:
         text_model = self.sherlock_model
         sent = text_model.make_sentence()
         assert len(sent) != 0
 
-    def test_json(self):
+    def test_json(self) -> None:
         text_model = self.sherlock_model
         json_model = text_model.to_json()
         new_text_model = markovify.Text.from_json(json_model)
         sent = new_text_model.make_sentence()
         assert len(sent) != 0
 
-    def test_chain(self):
+    def test_chain(self) -> None:
         text_model = self.sherlock_model
         chain_json = text_model.chain.to_json()
 
@@ -41,34 +41,36 @@ class MarkovifyTestBase(unittest.TestCase):
         sent = new_text_model.make_sentence()
         assert len(sent) != 0
 
-    def test_make_sentence_with_start(self):
+    def test_make_sentence_with_start(self) -> None:
         text_model = self.sherlock_model
         start_str = "Sherlock Holmes"
         sent = text_model.make_sentence_with_start(start_str)
         assert sent is not None
         assert start_str == sent[: len(start_str)]
 
-    def test_make_sentence_with_start_one_word(self):
+    def test_make_sentence_with_start_one_word(self) -> None:
         text_model = self.sherlock_model
         start_str = "Sherlock"
         sent = text_model.make_sentence_with_start(start_str)
         assert sent is not None
         assert start_str == sent[: len(start_str)]
 
-    def test_make_sentence_with_start_one_word_that_doesnt_begin_a_sentence(self):
+    def test_make_sentence_with_start_one_word_that_doesnt_begin_a_sentence(
+        self,
+    ) -> None:
         text_model = self.sherlock_model
         start_str = "dog"
         with self.assertRaises(KeyError):
             text_model.make_sentence_with_start(start_str)
 
-    def test_make_sentence_with_word_not_at_start_of_sentence(self):
+    def test_make_sentence_with_word_not_at_start_of_sentence(self) -> None:
         text_model = self.sherlock_model
         start_str = "dog"
         sent = text_model.make_sentence_with_start(start_str, strict=False)
         assert sent is not None
         assert start_str == sent[: len(start_str)]
 
-    def test_make_sentence_with_words_not_at_start_of_sentence(self):
+    def test_make_sentence_with_words_not_at_start_of_sentence(self) -> None:
         text_model = self.sherlock_model_ss3
         # " I was " has 128 matches in sherlock.txt
         # " was I " has 2 matches in sherlock.txt
@@ -77,26 +79,28 @@ class MarkovifyTestBase(unittest.TestCase):
         assert sent is not None
         assert start_str == sent[: len(start_str)]
 
-    def test_make_sentence_with_words_not_at_start_of_sentence_miss(self):
+    def test_make_sentence_with_words_not_at_start_of_sentence_miss(self) -> None:
         text_model = self.sherlock_model_ss3
         start_str = "was werewolf"
         with self.assertRaises(markovify.text.ParamError):
             text_model.make_sentence_with_start(start_str, strict=False, tries=50)
 
-    def test_make_sentence_with_words_not_at_start_of_sentence_of_state_size(self):
+    def test_make_sentence_with_words_not_at_start_of_sentence_of_state_size(
+        self,
+    ) -> None:
         text_model = self.sherlock_model_ss2
         start_str = "was I"
         sent = text_model.make_sentence_with_start(start_str, strict=False, tries=50)
         assert sent is not None
         assert start_str == sent[: len(start_str)]
 
-    def test_make_sentence_with_words_to_many(self):
+    def test_make_sentence_with_words_to_many(self) -> None:
         text_model = self.sherlock_model
         start_str = "dog is good"
         with self.assertRaises(markovify.text.ParamError):
             text_model.make_sentence_with_start(start_str, strict=False)
 
-    def test_make_sentence_with_start_three_words(self):
+    def test_make_sentence_with_start_three_words(self) -> None:
         start_str = "Sherlock Holmes was"
         text_model = self.sherlock_model
         try:
@@ -111,36 +115,36 @@ class MarkovifyTestBase(unittest.TestCase):
         sent = text_model.make_sentence_with_start("Sherlock", tries=50)
         assert markovify.chain.BEGIN not in sent
 
-    def test_short_sentence(self):
+    def test_short_sentence(self) -> None:
         text_model = self.sherlock_model
         sent = None
         while sent is None:
             sent = text_model.make_short_sentence(45)
         assert len(sent) <= 45
 
-    def test_short_sentence_min_chars(self):
+    def test_short_sentence_min_chars(self) -> None:
         sent = None
         while sent is None:
             sent = self.sherlock_model.make_short_sentence(100, min_chars=50)
         assert len(sent) <= 100
         assert len(sent) >= 50
 
-    def test_dont_test_output(self):
+    def test_dont_test_output(self) -> None:
         text_model = self.sherlock_model
         sent = text_model.make_sentence(test_output=False)
         assert sent is not None
 
-    def test_max_words(self):
+    def test_max_words(self) -> None:
         text_model = self.sherlock_model
         sent = text_model.make_sentence(max_words=0)
         assert sent is None
 
-    def test_min_words(self):
+    def test_min_words(self) -> None:
         text_model = self.sherlock_model
         sent = text_model.make_sentence(min_words=5)
         assert len(sent.split(" ")) >= 5
 
-    def test_newline_text(self):
+    def test_newline_text(self) -> None:
         with open(
             os.path.join(os.path.dirname(__file__), "texts/senate-bills.txt"),
             encoding="utf-8",
@@ -148,15 +152,15 @@ class MarkovifyTestBase(unittest.TestCase):
             model = markovify.NewlineText(f.read())
         model.make_sentence()
 
-    def test_bad_corpus(self):
+    def test_bad_corpus(self) -> None:
         with self.assertRaises(Exception):
-            markovify.Chain(corpus="testing, testing", state_size=2)
+            markovify.Chain(corpus="testing, testing", state_size=2)  # type: ignore
 
-    def test_bad_json(self):
+    def test_bad_json(self) -> None:
         with self.assertRaises(Exception):
-            markovify.Chain.from_json(1)
+            markovify.Chain.from_json(1)  # type: ignore
 
-    def test_custom_regex(self):
+    def test_custom_regex(self) -> None:
         with self.assertRaises(Exception):
             markovify.NewlineText(
                 "This sentence contains a custom bad character: #.", reject_reg=r"#"
@@ -187,7 +191,7 @@ class MarkovifyTestCompiled(MarkovifyTestBase):
         sherlock_model_ss2 = (markovify.Text(sherlock_text, state_size=2)).compile()
         sherlock_model_ss3 = (markovify.Text(sherlock_text, state_size=3)).compile()
 
-    def test_recompiling(self):
+    def test_recompiling(self) -> None:
         model_recompile = self.sherlock_model.compile()
         sent = model_recompile.make_sentence()
         assert len(sent) != 0

--- a/test/test_combine.py
+++ b/test/test_combine.py
@@ -16,74 +16,74 @@ with open(os.path.join(os.path.dirname(__file__), "texts/sherlock.txt")) as f:
 
 
 class MarkovifyTest(unittest.TestCase):
-    def test_simple(self):
+    def test_simple(self) -> None:
         text_model = sherlock_model
         combo = markovify.combine([text_model, text_model], [0.5, 0.5])
         assert combo.chain.model == text_model.chain.model
 
-    def test_double_weighted(self):
+    def test_double_weighted(self) -> None:
         text_model = sherlock_model
         combo = markovify.combine([text_model, text_model])
         assert combo.chain.model != text_model.chain.model
 
-    def test_combine_chains(self):
+    def test_combine_chains(self) -> None:
         chain = sherlock_model.chain
         markovify.combine([chain, chain])
 
-    def test_combine_dicts(self):
+    def test_combine_dicts(self) -> None:
         _dict = sherlock_model.chain.model
         markovify.combine([_dict, _dict])
 
-    def test_combine_lists(self):
+    def test_combine_lists(self) -> None:
         _list = list(sherlock_model.chain.model.items())
         markovify.combine([_list, _list])
 
-    def test_bad_types(self):
+    def test_bad_types(self) -> None:
         with self.assertRaises(Exception):
             markovify.combine(["testing", "testing"])
 
-    def test_bad_weights(self):
+    def test_bad_weights(self) -> None:
         with self.assertRaises(Exception):
             text_model = sherlock_model
             markovify.combine([text_model, text_model], [0.5])
 
-    def test_mismatched_state_sizes(self):
+    def test_mismatched_state_sizes(self) -> None:
         with self.assertRaises(Exception):
             text_model_a = markovify.Text(sherlock, state_size=2)
             text_model_b = markovify.Text(sherlock, state_size=3)
             markovify.combine([text_model_a, text_model_b])
 
-    def test_mismatched_model_types(self):
+    def test_mismatched_model_types(self) -> None:
         with self.assertRaises(Exception):
             text_model_a = sherlock_model
             text_model_b = markovify.NewlineText(sherlock)
             markovify.combine([text_model_a, text_model_b])
 
-    def test_compiled_model_fail(self):
+    def test_compiled_model_fail(self) -> None:
         with self.assertRaises(Exception):
             model_a = sherlock_model
             model_b = sherlock_model_compiled
             markovify.combine([model_a, model_b])
 
-    def test_compiled_chain_fail(self):
+    def test_compiled_chain_fail(self) -> None:
         with self.assertRaises(Exception):
             model_a = sherlock_model.chain
             model_b = sherlock_model_compiled.chain
             markovify.combine([model_a, model_b])
 
-    def test_combine_no_retain(self):
+    def test_combine_no_retain(self) -> None:
         text_model = sherlock_model_no_retain
         combo = markovify.combine([text_model, text_model])
         assert not combo.retain_original
 
-    def test_combine_retain_on_no_retain(self):
+    def test_combine_retain_on_no_retain(self) -> None:
         text_model_a = sherlock_model_no_retain
         text_model_b = sherlock_model
         combo = markovify.combine([text_model_a, text_model_b])
         assert combo.retain_original
         assert combo.parsed_sentences == text_model_b.parsed_sentences
 
-    def test_combine_no_retain_on_retain(self):
+    def test_combine_no_retain_on_retain(self) -> None:
         text_model_a = sherlock_model_no_retain
         text_model_b = sherlock_model
         combo = markovify.combine([text_model_b, text_model_a])

--- a/test/test_itertext.py
+++ b/test/test_itertext.py
@@ -4,14 +4,14 @@ import os
 
 
 class MarkovifyTest(unittest.TestCase):
-    def test_simple(self):
+    def test_simple(self) -> None:
         with open(os.path.join(os.path.dirname(__file__), "texts/sherlock.txt")) as f:
             sherlock_model = markovify.Text(f)
         sent = sherlock_model.make_sentence()
         assert sent is not None
         assert len(sent) != 0
 
-    def test_without_retaining(self):
+    def test_without_retaining(self) -> None:
         with open(
             os.path.join(os.path.dirname(__file__), "texts/senate-bills.txt"),
             encoding="utf-8",
@@ -21,7 +21,7 @@ class MarkovifyTest(unittest.TestCase):
         assert sent is not None
         assert len(sent) != 0
 
-    def test_from_json_without_retaining(self):
+    def test_from_json_without_retaining(self) -> None:
         with open(
             os.path.join(os.path.dirname(__file__), "texts/senate-bills.txt"),
             encoding="utf-8",
@@ -33,7 +33,7 @@ class MarkovifyTest(unittest.TestCase):
         assert sent is not None
         assert len(sent) != 0
 
-    def test_from_mult_files_without_retaining(self):
+    def test_from_mult_files_without_retaining(self) -> None:
         models = []
         for dirpath, _, filenames in os.walk(
             os.path.join(os.path.dirname(__file__), "texts")


### PR DESCRIPTION
Hello!

I am a long-time user of markovify, and my most recent project has involved a lot of interacting with Chain internals. I'm used to being able to know things' argument and return types in my IDE, but markovify doesn't have type annotations, and [lately](https://github.com/garlic-os/conversational-markov/) I've been really butting up against that.

**Well, one thing led to another, and I ended up adding type annotations to the entire package.**  
Here is what I have, after cleaning it up a little and making sure it works in the range of Python versions I am aware that markovify supports. Please take a look.

- All tests pass
- Coverage is still 100%* in the business logic
- `make format` returns no changes
- `make lint` returns no changes
- Tested in Python 3.6.8 and 3.13.2

The whole thing is type annotated. These are the changes made beside pure type annotations:
- To support certain typing symbols in lower Python versions, `typing_extensions` is added as a dev dependency. No new runtime dependencies are added, and this is not imported at runtime.
- *Project-wide `pytest-cov` code coverage decreased slightly due to the addition of some code that only runs while type checking, and an `assert_never()` to appease Pylance at a certain [unreachable line](https://github.com/jsvine/markovify/compare/master...garlic-os:markovify:master?expand=1#diff-69a66d1e5ca73cb305a6ca9ae48e6388d7706ba0102a55dbe661f9946ac9c8c3R104).
- `cast_not_none()` helper function added to `chain.py` and `text.py`.
- The Nexts of a compiled model are now tuples instead of lists, in order to express that `words` and `cff` are different types and that it's always just those two items inside it. [`chain.compile_next()`'s return type is changed accordingly](https://github.com/jsvine/markovify/compare/master...garlic-os:markovify:master?expand=1#diff-695cd9d01ac8d7812ed127a792747f4e62934f9d615ba0f5593769655f6c2cc3R61), and [logic was added to `from_json()`](https://github.com/jsvine/markovify/compare/master...garlic-os:markovify:master?expand=1#diff-695cd9d01ac8d7812ed127a792747f4e62934f9d615ba0f5593769655f6c2cc3R220) to convert a rehydrated, compiled model's Nexts to tuples.
	-  If we decide we aren't comfortable with this and want it to remain a list, I can accommodate that.</summary>
One alternative could be to change compiled Nexts back to a list and say it can hold either lists of ints or lists of strings, and then cast the elements as they're used (like in `move()`).
- A None check was added in [`Chain`](https://github.com/jsvine/markovify/compare/master...garlic-os:markovify:master?expand=1#diff-695cd9d01ac8d7812ed127a792747f4e62934f9d615ba0f5593769655f6c2cc3R90) and [`Text`'s constructors](https://github.com/jsvine/markovify/compare/master...garlic-os:markovify:master?expand=1#diff-cfe54a37d7e936c77ed4911fccde1a2440243885ac8d7f8427d9dcff7baca7d7R108) to ensure that at least one source of data is provided (e.g., that `model` is provided if `corpus` is not).
	- Previous behaviors in these spots led to runtime errors from trying to do unsupported operations on None.